### PR TITLE
refactor: adopt state machine pattern for client lifecycle

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,19 +11,22 @@
 import { Overlay } from "./overlay.js";
 import { inspect, findNearestSource, findNearestComponent } from "./inspector.js";
 import { AgentBridge } from "./agent-bridge.js";
+import { StateMachine } from "./state-machine.js";
 import type { AstroGrabOptions, GrabbedContext } from "./types.js";
 
 export type { AstroGrabOptions, GrabbedContext, SourceLocation, ComponentInfo } from "./types.js";
 export { inspect } from "./inspector.js";
+export { StateMachine } from "./state-machine.js";
+export type { ClientState, StateListener } from "./state-machine.js";
 
 // ── State ────────────────────────────────────────────────────────────
 
 let initialized = false;
 let overlay: Overlay;
 let bridge: AgentBridge | null = null;
+let stateMachine: StateMachine;
 let opts: Required<Omit<AstroGrabOptions, "onGrab" | "agentUrl">> & Pick<AstroGrabOptions, "onGrab" | "agentUrl">;
 
-let keyHeld = false;
 let hoveredEl: HTMLElement | null = null;
 
 // ── Key handling ─────────────────────────────────────────────────────
@@ -40,7 +43,8 @@ function isActivationKey(e: KeyboardEvent): boolean {
 
 function onKeyDown(e: KeyboardEvent) {
   if (!isActivationKey(e)) return;
-  keyHeld = true;
+
+  stateMachine.transition("targeting");
   overlay.setBadge(`\u26A1 astro-grab [${opts.key}]`);
   document.body.style.cursor = "crosshair";
 
@@ -52,9 +56,9 @@ function onKeyDown(e: KeyboardEvent) {
 
 function onKeyUp(e: KeyboardEvent) {
   if (!isActivationKey(e)) return;
-  keyHeld = false;
+
+  stateMachine.transition("idle");
   overlay.setBadge("\u26A1 astro-grab");
-  overlay.clearHighlight();
   document.body.style.cursor = "";
   hoveredEl = null;
 }
@@ -85,7 +89,7 @@ function highlightElement(el: HTMLElement) {
 }
 
 function onMouseMove(e: MouseEvent) {
-  if (!keyHeld) return;
+  if (stateMachine.getState() !== "targeting") return;
 
   const target = findGrabbableTarget(e.target);
   if (!target) return;
@@ -95,7 +99,7 @@ function onMouseMove(e: MouseEvent) {
 }
 
 function onMouseDown(e: MouseEvent) {
-  if (!keyHeld) return;
+  if (stateMachine.getState() !== "targeting") return;
 
   const target = findGrabbableTarget(e.target);
   if (!target) return;
@@ -128,7 +132,7 @@ function onMouseDown(e: MouseEvent) {
 }
 
 function onClick(e: MouseEvent) {
-  if (!keyHeld) return;
+  if (stateMachine.getState() !== "targeting") return;
 
   // Block clicks on the underlying page while grabbing
   e.preventDefault();
@@ -157,9 +161,8 @@ async function copyToClipboard(text: string) {
 // ── Blur handling (key release when window loses focus) ──────────────
 
 function onBlur() {
-  if (keyHeld) {
-    keyHeld = false;
-    overlay.clearHighlight();
+  if (stateMachine.getState() === "targeting") {
+    stateMachine.transition("idle");
     document.body.style.cursor = "";
     hoveredEl = null;
   }
@@ -182,8 +185,10 @@ export function initAstroGrab(options: AstroGrabOptions = {}) {
     agentUrl: options.agentUrl,
   };
 
-  // Create overlay
+  // Create state machine and overlay
+  stateMachine = new StateMachine();
   overlay = new Overlay();
+  overlay.connectStateMachine(stateMachine);
 
   // Wait for DOM to be ready
   if (document.readyState === "loading") {
@@ -231,6 +236,7 @@ export function destroyAstroGrab() {
   document.removeEventListener("click", onClick, true);
   window.removeEventListener("blur", onBlur);
 
+  stateMachine.reset();
   overlay.unmount();
   bridge?.disconnect();
   bridge = null;

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -7,6 +7,7 @@
  */
 
 import type { SourceLocation } from "./types.js";
+import type { StateMachine } from "./state-machine.js";
 
 // ── Styles ───────────────────────────────────────────────────────────
 
@@ -111,6 +112,7 @@ export class Overlay {
   private badgeEl: HTMLDivElement;
   private toastTimeout: ReturnType<typeof setTimeout> | null = null;
   private _mounted = false;
+  private unsubscribeState: (() => void) | null = null;
 
   constructor() {
     this.styleEl = document.createElement("style");
@@ -147,11 +149,29 @@ export class Overlay {
     if (!this._mounted) return;
     this._mounted = false;
 
+    this.unsubscribeState?.();
+    this.unsubscribeState = null;
+
     this.styleEl.remove();
     this.overlayEl.remove();
     this.tooltipEl.remove();
     this.toastEl.remove();
     this.badgeEl.remove();
+  }
+
+  /**
+   * Wire the overlay to a state machine.
+   * `targeting` → show overlay elements, `idle` → hide overlay + clear highlight.
+   */
+  connectStateMachine(sm: StateMachine): void {
+    // Clean up any previous subscription
+    this.unsubscribeState?.();
+
+    this.unsubscribeState = sm.subscribe((state) => {
+      if (state === "idle") {
+        this.clearHighlight();
+      }
+    });
   }
 
   /** Position the overlay highlight over a target element */

--- a/src/state-machine.ts
+++ b/src/state-machine.ts
@@ -1,0 +1,56 @@
+/**
+ * state-machine.ts
+ *
+ * Minimal state machine for the astro-grab client lifecycle.
+ * Drives overlay visibility and inspector activation via
+ * subscribe-based state transitions.
+ */
+
+// ── Types ─────────────────────────────────────────────────────────────
+
+export type ClientState = "idle" | "targeting";
+
+export interface StateListener {
+  (state: ClientState): void;
+}
+
+// ── StateMachine ──────────────────────────────────────────────────────
+
+export class StateMachine {
+  private state: ClientState = "idle";
+  private listeners = new Set<StateListener>();
+
+  getState(): ClientState {
+    return this.state;
+  }
+
+  /**
+   * Transition to a new state. No-ops if the state is unchanged.
+   * Notifies all subscribers when a transition occurs.
+   */
+  transition(newState: ClientState): void {
+    if (this.state === newState) return;
+
+    this.state = newState;
+
+    for (const listener of this.listeners) {
+      listener(newState);
+    }
+  }
+
+  /**
+   * Subscribe to all state transitions.
+   * Returns an unsubscribe function.
+   */
+  subscribe(listener: StateListener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /** Reset the machine back to idle. */
+  reset(): void {
+    this.transition("idle");
+  }
+}

--- a/tests/state-machine.test.ts
+++ b/tests/state-machine.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { StateMachine } from "../src/state-machine.js";
+import type { ClientState } from "../src/state-machine.js";
+
+describe("StateMachine", () => {
+  let sm: StateMachine;
+
+  beforeEach(() => {
+    sm = new StateMachine();
+  });
+
+  describe("initial state", () => {
+    it("starts in idle", () => {
+      expect(sm.getState()).toBe("idle");
+    });
+  });
+
+  describe("transition", () => {
+    it("transitions from idle to targeting", () => {
+      sm.transition("targeting");
+      expect(sm.getState()).toBe("targeting");
+    });
+
+    it("transitions from targeting to idle", () => {
+      sm.transition("targeting");
+      sm.transition("idle");
+      expect(sm.getState()).toBe("idle");
+    });
+
+    it("is a no-op when transitioning to the same state", () => {
+      const calls: ClientState[] = [];
+      sm.subscribe((state) => calls.push(state));
+
+      sm.transition("idle"); // already idle — should not fire
+      expect(calls).toEqual([]);
+      expect(sm.getState()).toBe("idle");
+    });
+
+    it("is a no-op for targeting → targeting", () => {
+      sm.transition("targeting");
+
+      const calls: ClientState[] = [];
+      sm.subscribe((state) => calls.push(state));
+
+      sm.transition("targeting"); // already targeting — should not fire
+      expect(calls).toEqual([]);
+      expect(sm.getState()).toBe("targeting");
+    });
+  });
+
+  describe("subscribe", () => {
+    it("notifies listener on transition", () => {
+      const calls: ClientState[] = [];
+      sm.subscribe((state) => calls.push(state));
+
+      sm.transition("targeting");
+      expect(calls).toEqual(["targeting"]);
+    });
+
+    it("notifies listener for each transition", () => {
+      const calls: ClientState[] = [];
+      sm.subscribe((state) => calls.push(state));
+
+      sm.transition("targeting");
+      sm.transition("idle");
+      sm.transition("targeting");
+      expect(calls).toEqual(["targeting", "idle", "targeting"]);
+    });
+
+    it("supports multiple subscribers", () => {
+      const callsA: ClientState[] = [];
+      const callsB: ClientState[] = [];
+      sm.subscribe((state) => callsA.push(state));
+      sm.subscribe((state) => callsB.push(state));
+
+      sm.transition("targeting");
+      expect(callsA).toEqual(["targeting"]);
+      expect(callsB).toEqual(["targeting"]);
+    });
+
+    it("returns an unsubscribe function", () => {
+      const calls: ClientState[] = [];
+      const unsubscribe = sm.subscribe((state) => calls.push(state));
+
+      sm.transition("targeting");
+      expect(calls).toEqual(["targeting"]);
+
+      unsubscribe();
+
+      sm.transition("idle");
+      // Should NOT have received the idle notification
+      expect(calls).toEqual(["targeting"]);
+    });
+
+    it("unsubscribe is safe to call multiple times", () => {
+      const calls: ClientState[] = [];
+      const unsubscribe = sm.subscribe((state) => calls.push(state));
+
+      unsubscribe();
+      unsubscribe(); // second call should be harmless
+
+      sm.transition("targeting");
+      expect(calls).toEqual([]);
+    });
+  });
+
+  describe("reset", () => {
+    it("restores idle from targeting", () => {
+      sm.transition("targeting");
+      sm.reset();
+      expect(sm.getState()).toBe("idle");
+    });
+
+    it("is a no-op when already idle", () => {
+      const calls: ClientState[] = [];
+      sm.subscribe((state) => calls.push(state));
+
+      sm.reset();
+      expect(sm.getState()).toBe("idle");
+      expect(calls).toEqual([]);
+    });
+
+    it("notifies subscribers when resetting from non-idle", () => {
+      sm.transition("targeting");
+
+      const calls: ClientState[] = [];
+      sm.subscribe((state) => calls.push(state));
+
+      sm.reset();
+      expect(calls).toEqual(["idle"]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Introduces a `StateMachine` class (`src/state-machine.ts`) with typed `idle` and `targeting` states, `transition()`, `getState()`, `subscribe()` (returns unsubscribe fn), and `reset()` methods
- Refactors `src/index.ts` to drive all lifecycle logic through state machine transitions instead of a raw `keyHeld` boolean -- key down transitions to `targeting`, key up / Escape / blur transitions to `idle`
- Wires the overlay to the state machine via a new `connectStateMachine()` method on `Overlay`, so `idle` transitions automatically clear highlights
- Adds 13 tests covering all transitions, subscribe/unsubscribe, reset, no-op same-state transitions, and multiple subscribers

Closes #3

## Test plan

- [x] `bun test` -- all 59 tests pass (13 new state machine tests + 46 existing)
- [x] `bun run build` -- tsup builds all three entry points cleanly
- [x] `tsc --noEmit` -- zero type errors
- [ ] Manual: hold activation key, verify crosshair cursor + overlay highlights appear
- [ ] Manual: release key, verify overlay clears and cursor resets
- [ ] Manual: click while targeting, verify clipboard copy / agent bridge still works
- [ ] Manual: `window.__ASTRO_GRAB__` API still functional (init/destroy/inspect)
