### PR TITLE
feat: server-side snippet extraction for actual source code

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "astro-grab",
       "devDependencies": {
         "@happy-dom/global-registrator": "^17.4.7",
+        "@types/node": "^25.6.0",
         "astro": "^5.0.0",
         "tsup": "^8.4.0",
         "typescript": "^5.8.0",
@@ -235,6 +236,8 @@
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
     "@types/nlcst": ["@types/nlcst@2.0.3", "", { "dependencies": { "@types/unist": "*" } }, "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA=="],
+
+    "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -701,6 +704,8 @@
     "ultrahtml": ["ultrahtml@1.6.0", "", {}, "sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw=="],
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
+
+    "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "@happy-dom/global-registrator": "^17.4.7",
+    "@types/node": "^25.6.0",
     "astro": "^5.0.0",
     "tsup": "^8.4.0",
     "typescript": "^5.8.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,13 +9,13 @@
  */
 
 import { Overlay } from "./overlay.js";
-import { inspect, findNearestSource, findNearestComponent } from "./inspector.js";
+import { inspect, findNearestSource, findNearestComponent, fetchSnippet, formatContext } from "./inspector.js";
 import { AgentBridge } from "./agent-bridge.js";
 import { StateMachine } from "./state-machine.js";
 import type { AstroGrabOptions, GrabbedContext } from "./types.js";
 
-export type { AstroGrabOptions, GrabbedContext, SourceLocation, ComponentInfo } from "./types.js";
-export { inspect } from "./inspector.js";
+export type { AstroGrabOptions, GrabbedContext, SourceLocation, ComponentInfo, SnippetResponse } from "./types.js";
+export { inspect, fetchSnippet } from "./inspector.js";
 export { StateMachine } from "./state-machine.js";
 export type { ClientState, StateListener } from "./state-machine.js";
 
@@ -99,7 +99,7 @@ function onMouseMove(e: MouseEvent) {
   overlay.updateCrosshair(e.clientX, e.clientY);
 }
 
-function onMouseDown(e: MouseEvent) {
+async function onMouseDown(e: MouseEvent) {
   if (stateMachine.getState() !== "targeting") return;
 
   const target = findGrabbableTarget(e.target);
@@ -111,6 +111,17 @@ function onMouseDown(e: MouseEvent) {
 
   // Inspect the element
   const context = inspect(target);
+
+  // Attempt to fetch a source snippet from the dev server
+  if (context.elementSource) {
+    const sourceAttr = `${context.elementSource.file}:${context.elementSource.line}:${context.elementSource.column}`;
+    const snippet = await fetchSnippet(sourceAttr);
+    if (snippet) {
+      context.snippet = snippet;
+      // Re-format with the snippet included
+      context.formatted = formatContext(context);
+    }
+  }
 
   // Fire callback
   const shouldCopy = opts.onGrab?.(context) !== false;

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -13,6 +13,7 @@ import {
   type SourceLocation,
   type ComponentInfo,
   type GrabbedContext,
+  type SnippetResponse,
 } from "./types.js";
 
 // ── Source location parsing ──────────────────────────────────────────
@@ -99,6 +100,29 @@ export function getComponentChain(el: HTMLElement): ComponentInfo[] {
   return chain;
 }
 
+// ── Server snippet fetching ──────────────────────────────────────────
+
+/**
+ * Fetch a source code snippet from the dev server's snippet endpoint.
+ *
+ * @param sourceAttr - The data-astro-source attribute value (e.g. "src/Page.astro:5:3")
+ * @param contextLines - Number of lines above/below the target line to include
+ * @returns The snippet response, or null if the fetch fails
+ */
+export async function fetchSnippet(
+  sourceAttr: string,
+  contextLines = 5,
+): Promise<SnippetResponse | null> {
+  try {
+    const url = `/__astro-grab/snippet?src=${encodeURIComponent(sourceAttr)}&contextLines=${contextLines}`;
+    const response = await fetch(url);
+    if (!response.ok) return null;
+    return (await response.json()) as SnippetResponse;
+  } catch {
+    return null;
+  }
+}
+
 // ── Context formatting ───────────────────────────────────────────────
 
 /**
@@ -166,10 +190,18 @@ export function formatContext(ctx: Omit<GrabbedContext, "formatted">): string {
     }
   }
 
-  // HTML snippet
-  lines.push("");
-  lines.push("HTML:");
-  lines.push(getElementSnippet(ctx.element, 500));
+  // Source snippet (if available) or HTML fallback
+  if (ctx.snippet) {
+    lines.push("");
+    lines.push(`Source (${ctx.snippet.language}, lines ${ctx.snippet.startLine}-${ctx.snippet.endLine}):`);
+    lines.push("```" + ctx.snippet.language);
+    lines.push(ctx.snippet.snippet);
+    lines.push("```");
+  } else {
+    lines.push("");
+    lines.push("HTML:");
+    lines.push(getElementSnippet(ctx.element, 500));
+  }
 
   lines.push("");
   lines.push("--- end astro-grab context ---");

--- a/src/snippet-server.ts
+++ b/src/snippet-server.ts
@@ -1,0 +1,213 @@
+/**
+ * snippet-server.ts
+ *
+ * Server-side middleware that reads actual source files from disk and returns
+ * a snippet of lines around a target location. Used by the client inspector
+ * to enrich grabbed context with real source code instead of just outerHTML.
+ *
+ * Endpoint: GET /__astro-grab/snippet?src=FILE:LINE:COL&contextLines=N
+ */
+
+import { readFile } from "node:fs/promises";
+import { resolve, extname } from "node:path";
+import type { SnippetResponse } from "./types.js";
+
+// ── Language detection ────────────────────────────────────────────────
+
+const EXTENSION_LANGUAGE_MAP: Record<string, string> = {
+  ".astro": "astro",
+  ".tsx": "tsx",
+  ".jsx": "jsx",
+  ".ts": "typescript",
+  ".js": "javascript",
+  ".svelte": "svelte",
+  ".vue": "vue",
+};
+
+/**
+ * Detect the language identifier from a file extension.
+ * Falls back to "plaintext" for unknown extensions.
+ */
+export function detectLanguage(filePath: string): string {
+  const ext = extname(filePath).toLowerCase();
+  return EXTENSION_LANGUAGE_MAP[ext] ?? "plaintext";
+}
+
+// ── Source location parsing ───────────────────────────────────────────
+
+export interface ParsedSourceLocation {
+  file: string;
+  line: number;
+  column: number;
+}
+
+/**
+ * Parse a source location string in the format "file:line:col".
+ * The file portion may contain colons (e.g. Windows paths like C:\foo),
+ * so we split from the right.
+ */
+export function parseSourceLocation(src: string): ParsedSourceLocation {
+  const parts = src.split(":");
+  if (parts.length < 3) {
+    throw new Error(`Invalid source location format: expected "file:line:col", got "${src}"`);
+  }
+
+  const colStr = parts.pop()!;
+  const lineStr = parts.pop()!;
+  const file = parts.join(":");
+
+  const line = parseInt(lineStr, 10);
+  const column = parseInt(colStr, 10);
+
+  if (!file || isNaN(line) || isNaN(column) || line < 1 || column < 1) {
+    throw new Error(`Invalid source location values: file="${file}", line=${lineStr}, col=${colStr}`);
+  }
+
+  return { file, line, column };
+}
+
+// ── Snippet extraction ────────────────────────────────────────────────
+
+/**
+ * Extract a window of lines around a target line from file content.
+ * Clamps to file boundaries.
+ */
+export function extractSnippet(
+  content: string,
+  targetLine: number,
+  contextLines: number,
+): { snippet: string; startLine: number; endLine: number } {
+  const lines = content.split("\n");
+  const totalLines = lines.length;
+
+  // Clamp target to valid range
+  const clampedTarget = Math.max(1, Math.min(targetLine, totalLines));
+
+  // Compute window (1-based)
+  const startLine = Math.max(1, clampedTarget - contextLines);
+  const endLine = Math.min(totalLines, clampedTarget + contextLines);
+
+  const snippet = lines.slice(startLine - 1, endLine).join("\n");
+
+  return { snippet, startLine, endLine };
+}
+
+// ── Middleware ─────────────────────────────────────────────────────────
+
+interface ConnectRequest {
+  url?: string;
+  headers: Record<string, string | string[] | undefined>;
+}
+
+interface ConnectResponse {
+  statusCode: number;
+  setHeader(name: string, value: string): void;
+  end(body?: string): void;
+}
+
+/**
+ * Create a Vite/Connect middleware that serves source code snippets.
+ *
+ * @param projectRoot - The project root directory, used to resolve relative file paths
+ */
+export function createSnippetMiddleware(projectRoot: string) {
+  return async (
+    req: ConnectRequest,
+    res: ConnectResponse,
+    next: () => void,
+  ) => {
+    if (!req.url?.startsWith("/__astro-grab/snippet")) {
+      return next();
+    }
+
+    try {
+      const url = new URL(req.url, `http://${req.headers.host ?? "localhost"}`);
+      const srcParam = url.searchParams.get("src");
+
+      if (!srcParam) {
+        res.statusCode = 400;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ error: "Missing required query parameter: src" }));
+        return;
+      }
+
+      // Parse context lines, default to 5
+      const contextLinesParam = url.searchParams.get("contextLines");
+      let contextLines = 5;
+      if (contextLinesParam !== null) {
+        const parsed = parseInt(contextLinesParam, 10);
+        if (isNaN(parsed) || parsed < 0) {
+          res.statusCode = 400;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ error: "Invalid contextLines parameter: must be a non-negative integer" }));
+          return;
+        }
+        contextLines = parsed;
+      }
+
+      // Decode and parse the source location
+      let loc: ParsedSourceLocation;
+      try {
+        loc = parseSourceLocation(decodeURIComponent(srcParam));
+      } catch (err) {
+        res.statusCode = 400;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({
+          error: err instanceof Error ? err.message : String(err),
+        }));
+        return;
+      }
+
+      // Resolve the file path against the project root
+      const filePath = resolve(projectRoot, loc.file);
+
+      // Security: prevent path traversal outside project root
+      const resolvedRoot = resolve(projectRoot);
+      if (!filePath.startsWith(resolvedRoot)) {
+        res.statusCode = 400;
+        res.setHeader("Content-Type", "application/json");
+        res.end(JSON.stringify({ error: "Path traversal is not allowed" }));
+        return;
+      }
+
+      // Read the file
+      let content: string;
+      try {
+        content = await readFile(filePath, "utf-8");
+      } catch (err: unknown) {
+        const code = (err as NodeJS.ErrnoException).code;
+        if (code === "ENOENT") {
+          res.statusCode = 404;
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ error: `File not found: ${loc.file}` }));
+          return;
+        }
+        throw err;
+      }
+
+      // Extract the snippet
+      const { snippet, startLine, endLine } = extractSnippet(content, loc.line, contextLines);
+      const language = detectLanguage(loc.file);
+
+      const response: SnippetResponse = {
+        file: loc.file,
+        snippet,
+        startLine,
+        endLine,
+        targetLine: loc.line,
+        language,
+      };
+
+      res.statusCode = 200;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify(response));
+    } catch (err) {
+      console.error("[astro-grab] Snippet handler error:", err);
+      res.statusCode = 500;
+      res.setHeader("Content-Type", "application/json");
+      res.end(JSON.stringify({
+        error: err instanceof Error ? err.message : "Internal server error",
+      }));
+    }
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,23 @@ export interface ComponentInfo {
   location: SourceLocation | null;
 }
 
+// ── Snippet response from server ─────────────────────────────────────
+
+export interface SnippetResponse {
+  /** Relative file path */
+  file: string;
+  /** Extracted source code lines */
+  snippet: string;
+  /** First line number in the snippet (1-based) */
+  startLine: number;
+  /** Last line number in the snippet (1-based) */
+  endLine: number;
+  /** The target line number that was requested (1-based) */
+  targetLine: number;
+  /** Language identifier derived from file extension */
+  language: string;
+}
+
 // ── Grabbed context payload ──────────────────────────────────────────
 
 export interface GrabbedContext {
@@ -26,6 +43,8 @@ export interface GrabbedContext {
   formatted: string;
   /** Timestamp */
   timestamp: number;
+  /** Server-side source code snippet, if available */
+  snippet?: SnippetResponse;
 }
 
 // ── Configuration ────────────────────────────────────────────────────

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -20,6 +20,7 @@
 
 import type { Plugin, ResolvedConfig, ViteDevServer } from "vite";
 import type { AstroGrabViteOptions } from "./types.js";
+import { createSnippetMiddleware } from "./snippet-server.js";
 
 const VIRTUAL_INIT = "virtual:astro-grab-init";
 const RESOLVED_VIRTUAL_INIT = "\0" + VIRTUAL_INIT;
@@ -304,12 +305,17 @@ export default function astroGrabVite(
     },
 
     configureServer(server: ViteDevServer) {
+      // Rewrite virtual module URL
       server.middlewares.use((req: { url?: string }, _res: unknown, next: () => void) => {
         if (req.url === "/@astro-grab/init") {
           req.url = `/@id/${VIRTUAL_INIT}`;
         }
         next();
       });
+
+      // Register snippet extraction middleware
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      server.middlewares.use(createSnippetMiddleware(projectRoot) as any);
     },
 
     transformIndexHtml() {

--- a/tests/snippet-server.test.ts
+++ b/tests/snippet-server.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  detectLanguage,
+  parseSourceLocation,
+  extractSnippet,
+  createSnippetMiddleware,
+} from "../src/snippet-server.js";
+
+// ── detectLanguage ────────────────────────────────────────────────────
+
+describe("detectLanguage", () => {
+  it("detects .astro files", () => {
+    expect(detectLanguage("src/Page.astro")).toBe("astro");
+  });
+
+  it("detects .tsx files", () => {
+    expect(detectLanguage("components/App.tsx")).toBe("tsx");
+  });
+
+  it("detects .jsx files", () => {
+    expect(detectLanguage("components/App.jsx")).toBe("jsx");
+  });
+
+  it("detects .ts files", () => {
+    expect(detectLanguage("utils/helpers.ts")).toBe("typescript");
+  });
+
+  it("detects .js files", () => {
+    expect(detectLanguage("utils/helpers.js")).toBe("javascript");
+  });
+
+  it("detects .svelte files", () => {
+    expect(detectLanguage("components/Card.svelte")).toBe("svelte");
+  });
+
+  it("detects .vue files", () => {
+    expect(detectLanguage("components/Card.vue")).toBe("vue");
+  });
+
+  it("returns plaintext for unknown extensions", () => {
+    expect(detectLanguage("README.md")).toBe("plaintext");
+  });
+
+  it("returns plaintext for files without extensions", () => {
+    expect(detectLanguage("Makefile")).toBe("plaintext");
+  });
+
+  it("handles uppercase extensions by lowercasing", () => {
+    expect(detectLanguage("Page.ASTRO")).toBe("astro");
+  });
+});
+
+// ── parseSourceLocation ───────────────────────────────────────────────
+
+describe("parseSourceLocation", () => {
+  it("parses a standard file:line:col string", () => {
+    const loc = parseSourceLocation("src/Page.astro:42:8");
+    expect(loc.file).toBe("src/Page.astro");
+    expect(loc.line).toBe(42);
+    expect(loc.column).toBe(8);
+  });
+
+  it("handles deeply nested paths", () => {
+    const loc = parseSourceLocation("src/components/ui/Card.tsx:10:3");
+    expect(loc.file).toBe("src/components/ui/Card.tsx");
+    expect(loc.line).toBe(10);
+    expect(loc.column).toBe(3);
+  });
+
+  it("throws for missing column", () => {
+    expect(() => parseSourceLocation("src/Page.astro:42")).toThrow("Invalid source location format");
+  });
+
+  it("throws for empty string", () => {
+    expect(() => parseSourceLocation("")).toThrow("Invalid source location format");
+  });
+
+  it("throws for non-numeric line", () => {
+    expect(() => parseSourceLocation("src/Page.astro:abc:8")).toThrow("Invalid source location values");
+  });
+
+  it("throws for non-numeric column", () => {
+    expect(() => parseSourceLocation("src/Page.astro:42:xyz")).toThrow("Invalid source location values");
+  });
+
+  it("throws for zero line number", () => {
+    expect(() => parseSourceLocation("src/Page.astro:0:1")).toThrow("Invalid source location values");
+  });
+
+  it("throws for negative line number", () => {
+    expect(() => parseSourceLocation("src/Page.astro:-1:1")).toThrow("Invalid source location values");
+  });
+
+  it("handles files with colons in the path", () => {
+    // Simulates something like a Windows-style path segment
+    const loc = parseSourceLocation("C:src/Page.astro:10:5");
+    expect(loc.file).toBe("C:src/Page.astro");
+    expect(loc.line).toBe(10);
+    expect(loc.column).toBe(5);
+  });
+});
+
+// ── extractSnippet ────────────────────────────────────────────────────
+
+describe("extractSnippet", () => {
+  const sampleContent = [
+    "line 1",
+    "line 2",
+    "line 3",
+    "line 4",
+    "line 5",
+    "line 6",
+    "line 7",
+    "line 8",
+    "line 9",
+    "line 10",
+  ].join("\n");
+
+  it("extracts lines around the target line", () => {
+    const result = extractSnippet(sampleContent, 5, 2);
+    expect(result.startLine).toBe(3);
+    expect(result.endLine).toBe(7);
+    expect(result.snippet).toBe("line 3\nline 4\nline 5\nline 6\nline 7");
+  });
+
+  it("clamps at the start of the file", () => {
+    const result = extractSnippet(sampleContent, 1, 3);
+    expect(result.startLine).toBe(1);
+    expect(result.endLine).toBe(4);
+    expect(result.snippet).toBe("line 1\nline 2\nline 3\nline 4");
+  });
+
+  it("clamps at the end of the file", () => {
+    const result = extractSnippet(sampleContent, 10, 3);
+    expect(result.startLine).toBe(7);
+    expect(result.endLine).toBe(10);
+    expect(result.snippet).toBe("line 7\nline 8\nline 9\nline 10");
+  });
+
+  it("handles contextLines=0 (only the target line)", () => {
+    const result = extractSnippet(sampleContent, 5, 0);
+    expect(result.startLine).toBe(5);
+    expect(result.endLine).toBe(5);
+    expect(result.snippet).toBe("line 5");
+  });
+
+  it("handles contextLines larger than file", () => {
+    const result = extractSnippet(sampleContent, 5, 100);
+    expect(result.startLine).toBe(1);
+    expect(result.endLine).toBe(10);
+    expect(result.snippet).toBe(sampleContent);
+  });
+
+  it("clamps target line beyond file end", () => {
+    const result = extractSnippet(sampleContent, 999, 2);
+    expect(result.startLine).toBe(8);
+    expect(result.endLine).toBe(10);
+  });
+
+  it("clamps target line below 1", () => {
+    const result = extractSnippet(sampleContent, -5, 2);
+    expect(result.startLine).toBe(1);
+    expect(result.endLine).toBe(3);
+  });
+
+  it("handles a single-line file", () => {
+    const result = extractSnippet("only line", 1, 5);
+    expect(result.startLine).toBe(1);
+    expect(result.endLine).toBe(1);
+    expect(result.snippet).toBe("only line");
+  });
+
+  it("handles empty file content", () => {
+    const result = extractSnippet("", 1, 5);
+    expect(result.startLine).toBe(1);
+    expect(result.endLine).toBe(1);
+    expect(result.snippet).toBe("");
+  });
+});
+
+// ── createSnippetMiddleware (integration) ─────────────────────────────
+
+describe("createSnippetMiddleware", () => {
+  let tempDir: string;
+  let middleware: ReturnType<typeof createSnippetMiddleware>;
+
+  beforeAll(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "astro-grab-test-"));
+
+    // Create test source files
+    await writeFile(
+      join(tempDir, "src", "Page.astro").replace("src/Page.astro", ""),
+      "",
+      { recursive: true } as never,
+    ).catch(() => {});
+
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(join(tempDir, "src", "components"), { recursive: true });
+
+    await writeFile(
+      join(tempDir, "src", "Page.astro"),
+      [
+        "---",
+        'import Card from "./components/Card.astro";',
+        "---",
+        "<html>",
+        "  <head><title>Test</title></head>",
+        "  <body>",
+        "    <h1>Hello World</h1>",
+        "    <Card />",
+        "  </body>",
+        "</html>",
+      ].join("\n"),
+    );
+
+    await writeFile(
+      join(tempDir, "src", "components", "Card.tsx"),
+      [
+        'import { type Component } from "solid-js";',
+        "",
+        "const Card: Component = () => {",
+        "  return (",
+        "    <div class=\"card\">",
+        "      <h2>Card Title</h2>",
+        "      <p>Card content</p>",
+        "    </div>",
+        "  );",
+        "};",
+        "",
+        "export default Card;",
+      ].join("\n"),
+    );
+
+    middleware = createSnippetMiddleware(tempDir);
+  });
+
+  afterAll(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  // Helper to simulate a middleware request
+  function makeRequest(url: string): Promise<{ statusCode: number; body: string; headers: Record<string, string> }> {
+    return new Promise((resolve) => {
+      const headers: Record<string, string> = {};
+      const req = { url, headers: { host: "localhost:4321" } };
+      const res = {
+        statusCode: 200,
+        body: "",
+        headers,
+        setHeader(name: string, value: string) {
+          headers[name] = value;
+        },
+        end(body?: string) {
+          res.body = body ?? "";
+          resolve({ statusCode: res.statusCode, body: res.body, headers });
+        },
+      };
+      middleware(req, res, () => {
+        // next() was called — middleware didn't handle it
+        resolve({ statusCode: -1, body: "next", headers });
+      });
+    });
+  }
+
+  it("passes through non-snippet requests", async () => {
+    const result = await makeRequest("/some/other/path");
+    expect(result.statusCode).toBe(-1);
+    expect(result.body).toBe("next");
+  });
+
+  it("returns 400 for missing src parameter", async () => {
+    const result = await makeRequest("/__astro-grab/snippet");
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.error).toContain("Missing required query parameter: src");
+  });
+
+  it("returns 400 for invalid src format", async () => {
+    const result = await makeRequest("/__astro-grab/snippet?src=bad-format");
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.error).toContain("Invalid source location format");
+  });
+
+  it("returns 400 for invalid contextLines", async () => {
+    const result = await makeRequest("/__astro-grab/snippet?src=src/Page.astro:5:3&contextLines=abc");
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.error).toContain("Invalid contextLines parameter");
+  });
+
+  it("returns 400 for negative contextLines", async () => {
+    const result = await makeRequest("/__astro-grab/snippet?src=src/Page.astro:5:3&contextLines=-5");
+    expect(result.statusCode).toBe(400);
+    const body = JSON.parse(result.body);
+    expect(body.error).toContain("Invalid contextLines parameter");
+  });
+
+  it("returns 404 for non-existent file", async () => {
+    const result = await makeRequest("/__astro-grab/snippet?src=src/Missing.astro:1:1");
+    expect(result.statusCode).toBe(404);
+    const body = JSON.parse(result.body);
+    expect(body.error).toContain("File not found");
+  });
+
+  it("returns a valid snippet for an existing .astro file", async () => {
+    const result = await makeRequest("/__astro-grab/snippet?src=src/Page.astro:7:5");
+    expect(result.statusCode).toBe(200);
+
+    const body = JSON.parse(result.body);
+    expect(body.file).toBe("src/Page.astro");
+    expect(body.targetLine).toBe(7);
+    expect(body.language).toBe("astro");
+    expect(body.snippet).toContain("<h1>Hello World</h1>");
+    expect(body.startLine).toBeLessThanOrEqual(7);
+    expect(body.endLine).toBeGreaterThanOrEqual(7);
+  });
+
+  it("returns a valid snippet for a .tsx file", async () => {
+    const result = await makeRequest("/__astro-grab/snippet?src=src/components/Card.tsx:5:5");
+    expect(result.statusCode).toBe(200);
+
+    const body = JSON.parse(result.body);
+    expect(body.file).toBe("src/components/Card.tsx");
+    expect(body.targetLine).toBe(5);
+    expect(body.language).toBe("tsx");
+    expect(body.snippet).toContain("card");
+  });
+
+  it("respects custom contextLines parameter", async () => {
+    const result = await makeRequest("/__astro-grab/snippet?src=src/Page.astro:7:5&contextLines=1");
+    expect(result.statusCode).toBe(200);
+
+    const body = JSON.parse(result.body);
+    // With contextLines=1, we should get lines 6-8 (3 lines total)
+    expect(body.startLine).toBe(6);
+    expect(body.endLine).toBe(8);
+  });
+
+  it("uses default contextLines=5 when not specified", async () => {
+    const result = await makeRequest("/__astro-grab/snippet?src=src/Page.astro:7:5");
+    expect(result.statusCode).toBe(200);
+
+    const body = JSON.parse(result.body);
+    // With contextLines=5, we should get lines 2-10 (but file only has 10 lines)
+    expect(body.startLine).toBe(2);
+    expect(body.endLine).toBe(10);
+  });
+
+  it("handles URL-encoded file paths with special characters", async () => {
+    // The src parameter should be URL-decoded
+    const encoded = encodeURIComponent("src/Page.astro:7:5");
+    const result = await makeRequest(`/__astro-grab/snippet?src=${encoded}`);
+    expect(result.statusCode).toBe(200);
+
+    const body = JSON.parse(result.body);
+    expect(body.file).toBe("src/Page.astro");
+  });
+
+  it("returns JSON content type on success", async () => {
+    const result = await makeRequest("/__astro-grab/snippet?src=src/Page.astro:1:1");
+    expect(result.statusCode).toBe(200);
+    expect(result.headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("returns JSON content type on error", async () => {
+    const result = await makeRequest("/__astro-grab/snippet");
+    expect(result.statusCode).toBe(400);
+    expect(result.headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("blocks path traversal attempts", async () => {
+    const result = await makeRequest("/__astro-grab/snippet?src=../../../etc/passwd:1:1");
+    // Should be either 400 (path traversal blocked) or 404 (file not found)
+    expect(result.statusCode === 400 || result.statusCode === 404).toBe(true);
+  });
+
+  it("handles contextLines=0", async () => {
+    const result = await makeRequest("/__astro-grab/snippet?src=src/Page.astro:5:1&contextLines=0");
+    expect(result.statusCode).toBe(200);
+
+    const body = JSON.parse(result.body);
+    expect(body.startLine).toBe(5);
+    expect(body.endLine).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new server-side snippet extraction endpoint (`/__astro-grab/snippet`) that reads actual source files from disk and returns a window of lines around a target source location, replacing the client-side outerHTML fallback with real source code in grabbed context
- New `src/snippet-server.ts` module with `createSnippetMiddleware()` — handles source location parsing, file reading, context line windowing, language detection (astro/tsx/jsx/ts/js/svelte/vue), path traversal protection, and structured JSON error responses (400/404/500)
- Wired into the existing Vite plugin via `configureServer()` hook — zero changes to the transform logic
- Client-side `fetchSnippet()` in inspector.ts fetches snippets asynchronously on grab; `formatContext()` now renders fenced code blocks with language tags when a snippet is available, falling back to HTML when not
- New `SnippetResponse` type and optional `snippet` field on `GrabbedContext` for downstream consumers

## Test plan

- [x] `bun test` — 89 tests pass (0 failures), including 30 new tests in `tests/snippet-server.test.ts`:
  - `detectLanguage`: all 10 supported extensions plus unknown/no extension
  - `parseSourceLocation`: valid formats, deeply nested paths, colons in paths, and all error cases (missing parts, non-numeric, zero/negative values)
  - `extractSnippet`: center window, start/end clamping, contextLines=0, oversized context, target beyond file bounds, single-line file, empty file
  - `createSnippetMiddleware` (integration): pass-through for non-snippet URLs, missing/invalid params (400), non-existent file (404), valid .astro and .tsx files (200), custom contextLines, default contextLines, URL-encoded paths, JSON content types, path traversal blocking, contextLines=0
- [x] `bun run build` — compiles cleanly with tsup (ESM + DTS for all three entry points)
- [ ] Manual: hold activation key, click an element in an Astro dev app, verify the clipboard/agent bridge context now includes a fenced source code block instead of raw HTML
