### PR TITLE
feat: crosshair overlay lines during element targeting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,6 +96,7 @@ function onMouseMove(e: MouseEvent) {
 
   hoveredEl = target;
   highlightElement(target);
+  overlay.updateCrosshair(e.clientX, e.clientY);
 }
 
 function onMouseDown(e: MouseEvent) {

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -100,6 +100,31 @@ const OVERLAY_STYLES = `
   }
 
   .astro-grab-badge:hover { opacity: 1; }
+
+  .astro-grab-crosshair {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 2147483646;
+    display: none;
+  }
+
+  .astro-grab-crosshair-line {
+    position: absolute;
+    background: rgba(188, 82, 238, 0.4);
+    pointer-events: none;
+  }
+
+  .ag-crosshair-v {
+    width: 1px;
+  }
+
+  .ag-crosshair-h {
+    height: 1px;
+  }
 `;
 
 // ── Overlay class ────────────────────────────────────────────────────
@@ -110,9 +135,15 @@ export class Overlay {
   private tooltipEl: HTMLDivElement;
   private toastEl: HTMLDivElement;
   private badgeEl: HTMLDivElement;
+  private crosshairEl: HTMLDivElement;
+  private lineTop: HTMLDivElement;
+  private lineBottom: HTMLDivElement;
+  private lineLeft: HTMLDivElement;
+  private lineRight: HTMLDivElement;
   private toastTimeout: ReturnType<typeof setTimeout> | null = null;
   private _mounted = false;
   private unsubscribeState: (() => void) | null = null;
+  private lastHighlightRect: DOMRect | null = null;
 
   constructor() {
     this.styleEl = document.createElement("style");
@@ -132,6 +163,26 @@ export class Overlay {
     this.badgeEl = document.createElement("div");
     this.badgeEl.className = "astro-grab-badge";
     this.badgeEl.textContent = "\u26A1 astro-grab";
+
+    // Crosshair container + 4 directional lines
+    this.crosshairEl = document.createElement("div");
+    this.crosshairEl.className = "astro-grab-crosshair";
+
+    this.lineTop = this.createCrosshairLine("ag-crosshair-v");
+    this.lineBottom = this.createCrosshairLine("ag-crosshair-v");
+    this.lineLeft = this.createCrosshairLine("ag-crosshair-h");
+    this.lineRight = this.createCrosshairLine("ag-crosshair-h");
+
+    this.crosshairEl.appendChild(this.lineTop);
+    this.crosshairEl.appendChild(this.lineBottom);
+    this.crosshairEl.appendChild(this.lineLeft);
+    this.crosshairEl.appendChild(this.lineRight);
+  }
+
+  private createCrosshairLine(directionClass: string): HTMLDivElement {
+    const line = document.createElement("div");
+    line.className = `astro-grab-crosshair-line ${directionClass}`;
+    return line;
   }
 
   mount() {
@@ -143,6 +194,7 @@ export class Overlay {
     document.body.appendChild(this.tooltipEl);
     document.body.appendChild(this.toastEl);
     document.body.appendChild(this.badgeEl);
+    document.body.appendChild(this.crosshairEl);
   }
 
   unmount() {
@@ -157,6 +209,7 @@ export class Overlay {
     this.tooltipEl.remove();
     this.toastEl.remove();
     this.badgeEl.remove();
+    this.crosshairEl.remove();
   }
 
   /**
@@ -170,6 +223,9 @@ export class Overlay {
     this.unsubscribeState = sm.subscribe((state) => {
       if (state === "idle") {
         this.clearHighlight();
+        this.hideCrosshair();
+      } else if (state === "targeting") {
+        this.crosshairEl.style.display = "block";
       }
     });
   }
@@ -177,6 +233,7 @@ export class Overlay {
   /** Position the overlay highlight over a target element */
   highlight(el: HTMLElement) {
     const rect = el.getBoundingClientRect();
+    this.lastHighlightRect = rect;
     const s = this.overlayEl.style;
     s.display = "block";
     s.top = rect.top + "px";
@@ -189,6 +246,7 @@ export class Overlay {
   clearHighlight() {
     this.overlayEl.style.display = "none";
     this.tooltipEl.style.display = "none";
+    this.lastHighlightRect = null;
   }
 
   /** Show the tooltip near the highlighted element */
@@ -223,6 +281,45 @@ export class Overlay {
 
     this.tooltipEl.style.top = top + "px";
     this.tooltipEl.style.left = left + "px";
+  }
+
+  /**
+   * Update crosshair lines to extend between the cursor and the
+   * currently highlighted element's bounding rect edges.
+   * If no element is highlighted, hides the crosshair lines.
+   */
+  updateCrosshair(cursorX: number, cursorY: number) {
+    const rect = this.lastHighlightRect;
+    if (!rect) {
+      this.hideCrosshair();
+      return;
+    }
+
+    // Top line: from viewport top (0) to element top, at cursorX
+    this.lineTop.style.left = cursorX + "px";
+    this.lineTop.style.top = "0";
+    this.lineTop.style.height = Math.max(0, rect.top) + "px";
+
+    // Bottom line: from element bottom to viewport bottom, at cursorX
+    this.lineBottom.style.left = cursorX + "px";
+    this.lineBottom.style.top = rect.bottom + "px";
+    this.lineBottom.style.height = Math.max(0, window.innerHeight - rect.bottom) + "px";
+
+    // Left line: from viewport left (0) to element left, at cursorY
+    this.lineLeft.style.left = "0";
+    this.lineLeft.style.top = cursorY + "px";
+    this.lineLeft.style.width = Math.max(0, rect.left) + "px";
+
+    // Right line: from element right to viewport right, at cursorY
+    this.lineRight.style.left = rect.right + "px";
+    this.lineRight.style.top = cursorY + "px";
+    this.lineRight.style.width = Math.max(0, window.innerWidth - rect.right) + "px";
+  }
+
+  /** Hide all crosshair lines */
+  hideCrosshair() {
+    this.crosshairEl.style.display = "none";
+    this.lastHighlightRect = null;
   }
 
   /** Flash a toast notification */

--- a/tests/overlay.test.ts
+++ b/tests/overlay.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { Overlay } from "../src/overlay.js";
+import { StateMachine } from "../src/state-machine.js";
 
 describe("Overlay", () => {
   let overlay: Overlay;
@@ -22,6 +23,22 @@ describe("Overlay", () => {
       expect(document.querySelector(".astro-grab-badge")).not.toBeNull();
     });
 
+    it("appends crosshair elements on mount", () => {
+      overlay.mount();
+
+      const crosshair = document.querySelector(".astro-grab-crosshair");
+      expect(crosshair).not.toBeNull();
+
+      const lines = crosshair!.querySelectorAll(".astro-grab-crosshair-line");
+      expect(lines.length).toBe(4);
+
+      // 2 vertical lines, 2 horizontal lines
+      const verticals = crosshair!.querySelectorAll(".ag-crosshair-v");
+      const horizontals = crosshair!.querySelectorAll(".ag-crosshair-h");
+      expect(verticals.length).toBe(2);
+      expect(horizontals.length).toBe(2);
+    });
+
     it("removes elements from DOM on unmount", () => {
       overlay.mount();
       overlay.unmount();
@@ -30,6 +47,7 @@ describe("Overlay", () => {
       expect(document.querySelector(".astro-grab-tooltip")).toBeNull();
       expect(document.querySelector(".astro-grab-toast")).toBeNull();
       expect(document.querySelector(".astro-grab-badge")).toBeNull();
+      expect(document.querySelector(".astro-grab-crosshair")).toBeNull();
     });
 
     it("is safe to call mount twice", () => {
@@ -88,6 +106,103 @@ describe("Overlay", () => {
       const toast = document.querySelector(".astro-grab-toast");
       expect(toast?.textContent).toBe("Test message");
       expect(toast?.classList.contains("ag-visible")).toBe(true);
+    });
+  });
+
+  describe("crosshair", () => {
+    it("crosshair container is hidden by default via CSS", () => {
+      overlay.mount();
+
+      // The crosshair is hidden via the stylesheet class (display: none in CSS),
+      // not inline style. Verify the element exists with the correct class.
+      const crosshair = document.querySelector(".astro-grab-crosshair") as HTMLDivElement;
+      expect(crosshair).not.toBeNull();
+      expect(crosshair.className).toBe("astro-grab-crosshair");
+    });
+
+    it("updateCrosshair positions lines when a highlight rect exists", () => {
+      overlay.mount();
+
+      // Highlight an element to set lastHighlightRect
+      const el = document.createElement("div");
+      document.body.appendChild(el);
+      overlay.highlight(el);
+
+      // Call updateCrosshair with a cursor position
+      overlay.updateCrosshair(150, 200);
+
+      const crosshair = document.querySelector(".astro-grab-crosshair") as HTMLDivElement;
+      const lines = crosshair.querySelectorAll(".astro-grab-crosshair-line");
+
+      // Top vertical line should be positioned at cursorX
+      const lineTop = lines[0] as HTMLDivElement;
+      expect(lineTop.style.left).toBe("150px");
+      expect(lineTop.style.top).toBe("0px");
+
+      // Bottom vertical line should be positioned at cursorX
+      const lineBottom = lines[1] as HTMLDivElement;
+      expect(lineBottom.style.left).toBe("150px");
+
+      // Left horizontal line should be positioned at cursorY
+      const lineLeft = lines[2] as HTMLDivElement;
+      expect(lineLeft.style.top).toBe("200px");
+      expect(lineLeft.style.left).toBe("0px");
+
+      // Right horizontal line should be positioned at cursorY
+      const lineRight = lines[3] as HTMLDivElement;
+      expect(lineRight.style.top).toBe("200px");
+    });
+
+    it("updateCrosshair hides crosshair when no highlight rect exists", () => {
+      overlay.mount();
+
+      // Show crosshair manually to verify it gets hidden
+      const crosshair = document.querySelector(".astro-grab-crosshair") as HTMLDivElement;
+      crosshair.style.display = "block";
+
+      // No element has been highlighted, so updateCrosshair should hide
+      overlay.updateCrosshair(100, 100);
+
+      expect(crosshair.style.display).toBe("none");
+    });
+
+    it("hideCrosshair hides the crosshair container", () => {
+      overlay.mount();
+
+      const crosshair = document.querySelector(".astro-grab-crosshair") as HTMLDivElement;
+      crosshair.style.display = "block";
+
+      overlay.hideCrosshair();
+
+      expect(crosshair.style.display).toBe("none");
+    });
+
+    it("crosshair is hidden when state transitions to idle", () => {
+      overlay.mount();
+
+      const sm = new StateMachine();
+      overlay.connectStateMachine(sm);
+
+      // Transition to targeting — crosshair becomes visible
+      sm.transition("targeting");
+      const crosshair = document.querySelector(".astro-grab-crosshair") as HTMLDivElement;
+      expect(crosshair.style.display).toBe("block");
+
+      // Transition back to idle — crosshair should be hidden
+      sm.transition("idle");
+      expect(crosshair.style.display).toBe("none");
+    });
+
+    it("crosshair becomes visible when state transitions to targeting", () => {
+      overlay.mount();
+
+      const sm = new StateMachine();
+      overlay.connectStateMachine(sm);
+
+      sm.transition("targeting");
+
+      const crosshair = document.querySelector(".astro-grab-crosshair") as HTMLDivElement;
+      expect(crosshair.style.display).toBe("block");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds crosshair overlay lines that extend from the cursor position to the highlighted element's bounding rect edges during element targeting mode
- Four directional lines (top, bottom, left, right) are rendered as thin 1px semi-transparent purple lines (`rgba(188, 82, 238, 0.4)`) matching the existing color scheme
- Crosshair visibility is driven by the state machine: shown on `targeting`, hidden on `idle`
- `updateCrosshair(cursorX, cursorY)` is called from the mousemove handler to reposition lines in real-time

## Test plan

- [x] All 66 tests pass (`bun test`)
- [x] Build compiles cleanly (`bun run build`)
- [x] New tests verify crosshair elements are created on mount (container + 4 lines with correct CSS classes)
- [x] New tests verify `updateCrosshair` positions lines correctly relative to cursor and highlight rect
- [x] New tests verify crosshair hides when no highlight rect exists
- [x] New tests verify crosshair visibility toggles with state machine transitions (targeting/idle)
- [ ] Manual: hold activation key, hover elements — crosshair lines should extend from cursor to element edges
- [ ] Manual: release key — crosshair lines disappear immediately

Closes #4
