### PR TITLE
feat: add overlay theme customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Hold a key, hover, click — grab any element's source context for AI agents. As
 ## Install
 
 ```bash
-bun add -D astro-grab
+bun add -D @omniaura/astro-grab
 # or
-npm install -D astro-grab
+npm install -D @omniaura/astro-grab
 ```
 
 ## Setup
@@ -16,7 +16,7 @@ Add the integration to your `astro.config.mjs`:
 
 ```js
 import { defineConfig } from "astro/config";
-import astroGrab from "astro-grab";
+import astroGrab from "@omniaura/astro-grab";
 
 export default defineConfig({
   integrations: [astroGrab()],
@@ -58,7 +58,11 @@ astroGrab({
   jsxLocation: true,      // Inject data-astro-source (default: true)
   componentLocation: true, // Inject data-astro-component (default: true)
   autoImport: true,        // Auto-import runtime in dev (default: true)
-  key: "Alt",              // Modifier key: "Alt" | "Control" | "Meta" (default: "Alt")
+  key: "Alt",              // Modifier key: "Alt" | "Control" | "Meta" | "Shift"
+  theme: {
+    accent: "#bc52ee",     // Optional theme overrides
+    surface: "#1a1a2e",
+  },
 })
 ```
 
@@ -67,15 +71,51 @@ astroGrab({
 For manual initialization (if `autoImport: false`):
 
 ```js
-import { initAstroGrab } from "astro-grab/client";
+import { initAstroGrab } from "@omniaura/astro-grab/client";
 
 initAstroGrab({
   key: "Alt",              // Modifier key (default: "Alt")
   showToast: true,         // Show notification on copy (default: true)
   agentUrl: "ws://...",    // WebSocket URL for agent bridge (optional)
   onGrab: (context) => {}, // Callback, return false to prevent copy
+  theme: {
+    accent: "#bc52ee",
+    surface: "#1a1a2e",
+  },
 });
 ```
+
+### Theme Defaults
+
+`astro-grab` now exposes its built-in OmniAura palette so you can extend it instead of re-creating it:
+
+```js
+import astroGrab, { DEFAULT_ASTRO_GRAB_THEME } from "@omniaura/astro-grab";
+
+export default defineConfig({
+  integrations: [
+    astroGrab({
+      key: "Alt",
+      theme: {
+        ...DEFAULT_ASTRO_GRAB_THEME,
+        accent: "#ff7a59",
+        accentSoft: "#ffd1c2",
+      },
+    }),
+  ],
+});
+```
+
+Available theme keys:
+
+- `accent`
+- `accentSoft`
+- `surface`
+- `text`
+- `overlay`
+- `border`
+- `crosshair`
+- `tag`
 
 ### Agent Bridge
 
@@ -91,7 +131,7 @@ astroGrab({
 Then in your client code:
 
 ```js
-import { initAstroGrab } from "astro-grab/client";
+import { initAstroGrab } from "@omniaura/astro-grab/client";
 
 initAstroGrab({
   agentUrl: "ws://localhost:4567",
@@ -119,7 +159,7 @@ If you're not using the Astro integration (e.g., in a plain Vite project):
 
 ```js
 import { defineConfig } from "vite";
-import astroGrab from "astro-grab/vite";
+import astroGrab from "@omniaura/astro-grab/vite";
 
 export default defineConfig({
   plugins: [astroGrab()],
@@ -134,6 +174,7 @@ Access the runtime programmatically via `window.__ASTRO_GRAB__`:
 window.__ASTRO_GRAB__.init({ key: "Control" });
 window.__ASTRO_GRAB__.destroy();
 window.__ASTRO_GRAB__.inspect(document.querySelector(".my-element"));
+console.log(window.__ASTRO_GRAB__.theme);
 ```
 
 ## Dev Only

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,14 +9,16 @@
  */
 
 import { Overlay } from "./overlay.js";
+import { DEFAULT_ASTRO_GRAB_THEME, resolveTheme } from "./theme.js";
 import { inspect, findNearestSource, findNearestComponent, fetchSnippet, formatContext } from "./inspector.js";
 import { AgentBridge } from "./agent-bridge.js";
 import { StateMachine } from "./state-machine.js";
-import type { AstroGrabOptions, GrabbedContext } from "./types.js";
+import type { AstroGrabOptions, AstroGrabTheme, GrabbedContext } from "./types.js";
 
-export type { AstroGrabOptions, GrabbedContext, SourceLocation, ComponentInfo, SnippetResponse } from "./types.js";
+export type { AstroGrabOptions, AstroGrabTheme, GrabbedContext, SourceLocation, ComponentInfo, SnippetResponse } from "./types.js";
 export { inspect, fetchSnippet } from "./inspector.js";
 export { StateMachine } from "./state-machine.js";
+export { DEFAULT_ASTRO_GRAB_THEME } from "./theme.js";
 export type { ClientState, StateListener } from "./state-machine.js";
 
 // ── State ────────────────────────────────────────────────────────────
@@ -25,7 +27,9 @@ let initialized = false;
 let overlay: Overlay;
 let bridge: AgentBridge | null = null;
 let stateMachine: StateMachine;
-let opts: Required<Omit<AstroGrabOptions, "onGrab" | "agentUrl">> & Pick<AstroGrabOptions, "onGrab" | "agentUrl">;
+let opts: Required<Pick<AstroGrabOptions, "key" | "showToast">> &
+  Pick<AstroGrabOptions, "onGrab" | "agentUrl">;
+let currentTheme: AstroGrabTheme = { ...DEFAULT_ASTRO_GRAB_THEME };
 
 let hoveredEl: HTMLElement | null = null;
 let enabled = true;
@@ -198,6 +202,14 @@ function emitStateChange(state: string) {
   );
 }
 
+function emitReady() {
+  window.dispatchEvent(
+    new CustomEvent("astro-grab:ready", {
+      detail: { key: opts.key, theme: currentTheme },
+    })
+  );
+}
+
 function onToolbarToggle(e: Event) {
   const detail = (e as CustomEvent<{ enabled: boolean }>).detail;
   if (!detail) return;
@@ -253,10 +265,14 @@ export function initAstroGrab(options: AstroGrabOptions = {}) {
     onGrab: options.onGrab,
     agentUrl: options.agentUrl,
   };
+  currentTheme = resolveTheme(options.theme);
+  if (typeof window !== "undefined") {
+    window.__ASTRO_GRAB__.theme = currentTheme;
+  }
 
   // Create state machine and overlay
   stateMachine = new StateMachine();
-  overlay = new Overlay();
+  overlay = new Overlay(currentTheme);
   overlay.connectStateMachine(stateMachine);
 
   // Wait for DOM to be ready
@@ -269,6 +285,7 @@ export function initAstroGrab(options: AstroGrabOptions = {}) {
 
 function bootstrap() {
   overlay.mount();
+  emitReady();
 
   // Set up event listeners
   window.addEventListener("keydown", onKeyDown, true);
@@ -290,7 +307,7 @@ function bootstrap() {
 
   console.log(
     `%c\u26A1 astro-grab%c Hold ${opts.key} + click to grab element context`,
-    "color: #d8b4fe; font-weight: bold",
+    `color: ${currentTheme.accentSoft}; font-weight: bold`,
     "color: inherit"
   );
 }
@@ -316,6 +333,10 @@ export function destroyAstroGrab() {
   bridge?.disconnect();
   bridge = null;
   enabled = true;
+  currentTheme = { ...DEFAULT_ASTRO_GRAB_THEME };
+  if (typeof window !== "undefined") {
+    window.__ASTRO_GRAB__.theme = currentTheme;
+  }
   document.body.style.cursor = "";
 }
 
@@ -335,6 +356,7 @@ declare global {
       init: typeof initAstroGrab;
       destroy: typeof destroyAstroGrab;
       inspect: typeof inspect;
+      theme: AstroGrabTheme;
     };
   }
 }
@@ -344,5 +366,6 @@ if (typeof window !== "undefined") {
     init: initAstroGrab,
     destroy: destroyAstroGrab,
     inspect,
+    theme: currentTheme,
   };
 }

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -14,9 +14,13 @@
  */
 
 import type { AstroIntegration } from "astro";
+import { resolveTheme } from "./theme.js";
 import { STORAGE_KEY } from "./toolbar.js";
 import type { AstroGrabIntegrationOptions } from "./types.js";
 import astroGrabVite from "./vite.js";
+
+export { DEFAULT_ASTRO_GRAB_THEME } from "./theme.js";
+export type { AstroGrabTheme } from "./types.js";
 
 export default function astroGrab(
   options: AstroGrabIntegrationOptions = {}
@@ -26,7 +30,10 @@ export default function astroGrab(
     componentLocation = true,
     autoImport = true,
     key = "Alt",
+    theme,
   } = options;
+
+  const resolvedTheme = resolveTheme(theme);
 
   return {
     name: "astro-grab",
@@ -47,6 +54,7 @@ export default function astroGrab(
               `import { initAstroGrab } from "@omniaura/astro-grab/client";`,
               `const storageKey = ${JSON.stringify(STORAGE_KEY)};`,
               `const configuredKey = ${JSON.stringify(key)};`,
+              `const configuredTheme = ${JSON.stringify(resolvedTheme)};`,
               `const validKeys = new Set(["Alt", "Control", "Meta", "Shift"]);`,
               `const readToolbarConfig = () => {`,
               `  try {`,
@@ -60,7 +68,7 @@ export default function astroGrab(
               `};`,
               `const toolbarConfig = readToolbarConfig();`,
               `const activationKey = validKeys.has(toolbarConfig?.key) ? toolbarConfig.key : configuredKey;`,
-              `initAstroGrab({ key: activationKey });`,
+              `initAstroGrab({ key: activationKey, theme: configuredTheme });`,
               `if (toolbarConfig?.enabled === false) {`,
               `  const disable = () => {`,
               `    window.dispatchEvent(new CustomEvent("astro-grab:toggle", { detail: { enabled: false } }));`,
@@ -83,6 +91,7 @@ export default function astroGrab(
                 componentLocation,
                 autoImport: false,
                 key,
+                theme: resolvedTheme,
               }),
             ],
           },

--- a/src/overlay.ts
+++ b/src/overlay.ts
@@ -6,18 +6,20 @@
  * with the app being inspected.
  */
 
-import type { SourceLocation } from "./types.js";
+import { resolveTheme } from "./theme.js";
 import type { StateMachine } from "./state-machine.js";
+import type { AstroGrabTheme, SourceLocation } from "./types.js";
 
 // ── Styles ───────────────────────────────────────────────────────────
 
-const OVERLAY_STYLES = `
+function createOverlayStyles(theme: AstroGrabTheme): string {
+  return `
   .astro-grab-overlay {
     position: fixed;
     pointer-events: none;
     z-index: 2147483647;
-    border: 2px solid #bc52ee;
-    background: rgba(188, 82, 238, 0.08);
+    border: 2px solid ${theme.accent};
+    background: ${theme.overlay};
     border-radius: 3px;
     transition: all 0.08s ease-out;
   }
@@ -26,14 +28,14 @@ const OVERLAY_STYLES = `
     position: fixed;
     z-index: 2147483647;
     pointer-events: none;
-    background: #1a1a2e;
-    color: #e0e0e0;
+    background: ${theme.surface};
+    color: ${theme.text};
     font-family: "SF Mono", "Fira Code", "Cascadia Code", monospace;
     font-size: 12px;
     line-height: 1.4;
     padding: 6px 10px;
     border-radius: 6px;
-    border: 1px solid rgba(188, 82, 238, 0.4);
+    border: 1px solid ${theme.border};
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
     max-width: 480px;
     white-space: nowrap;
@@ -42,17 +44,17 @@ const OVERLAY_STYLES = `
   }
 
   .astro-grab-tooltip .ag-component {
-    color: #d8b4fe;
+    color: ${theme.accentSoft};
     font-weight: 600;
   }
 
   .astro-grab-tooltip .ag-file {
-    color: #c4b5fd;
+    color: ${theme.accentSoft};
     opacity: 0.85;
   }
 
   .astro-grab-tooltip .ag-tag {
-    color: #86efac;
+    color: ${theme.tag};
   }
 
   .astro-grab-toast {
@@ -61,13 +63,13 @@ const OVERLAY_STYLES = `
     left: 50%;
     transform: translateX(-50%) translateY(0);
     z-index: 2147483647;
-    background: #1a1a2e;
-    color: #e0e0e0;
+    background: ${theme.surface};
+    color: ${theme.text};
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     font-size: 13px;
     padding: 10px 18px;
     border-radius: 8px;
-    border: 1px solid rgba(188, 82, 238, 0.3);
+    border: 1px solid ${theme.border};
     box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
     opacity: 0;
     transition: opacity 0.2s, transform 0.2s;
@@ -84,14 +86,14 @@ const OVERLAY_STYLES = `
     bottom: 12px;
     right: 12px;
     z-index: 2147483646;
-    background: #1a1a2e;
-    color: #d8b4fe;
+    background: ${theme.surface};
+    color: ${theme.accentSoft};
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     font-size: 11px;
     font-weight: 600;
     padding: 4px 10px;
     border-radius: 6px;
-    border: 1px solid rgba(188, 82, 238, 0.25);
+    border: 1px solid ${theme.border};
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
     cursor: default;
     user-select: none;
@@ -114,7 +116,7 @@ const OVERLAY_STYLES = `
 
   .astro-grab-crosshair-line {
     position: absolute;
-    background: rgba(188, 82, 238, 0.4);
+    background: ${theme.crosshair};
     pointer-events: none;
   }
 
@@ -126,6 +128,7 @@ const OVERLAY_STYLES = `
     height: 1px;
   }
 `;
+}
 
 // ── Overlay class ────────────────────────────────────────────────────
 
@@ -144,10 +147,12 @@ export class Overlay {
   private _mounted = false;
   private unsubscribeState: (() => void) | null = null;
   private lastHighlightRect: DOMRect | null = null;
+  readonly theme: AstroGrabTheme;
 
-  constructor() {
+  constructor(theme?: Partial<AstroGrabTheme>) {
+    this.theme = resolveTheme(theme);
     this.styleEl = document.createElement("style");
-    this.styleEl.textContent = OVERLAY_STYLES;
+    this.styleEl.textContent = createOverlayStyles(this.theme);
 
     this.overlayEl = document.createElement("div");
     this.overlayEl.className = "astro-grab-overlay";

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,37 @@
+import type { AstroGrabTheme } from "./types.js";
+
+export const DEFAULT_ASTRO_GRAB_THEME: AstroGrabTheme = {
+  accent: "#bc52ee",
+  accentSoft: "#d8b4fe",
+  surface: "#1a1a2e",
+  text: "#e0e0e0",
+  overlay: "rgba(188, 82, 238, 0.08)",
+  border: "rgba(188, 82, 238, 0.4)",
+  crosshair: "rgba(188, 82, 238, 0.4)",
+  tag: "#86efac",
+};
+
+export function resolveTheme(
+  theme?: Partial<AstroGrabTheme>
+): AstroGrabTheme {
+  if (!theme) {
+    return { ...DEFAULT_ASTRO_GRAB_THEME };
+  }
+
+  const resolved = { ...DEFAULT_ASTRO_GRAB_THEME };
+
+  for (const key of Object.keys(DEFAULT_ASTRO_GRAB_THEME) as Array<keyof AstroGrabTheme>) {
+    const value = theme[key];
+    if (typeof value === "string" && value.trim() !== "") {
+      resolved[key] = value;
+    }
+  }
+
+  return resolved;
+}
+
+export function isDefaultTheme(theme: AstroGrabTheme): boolean {
+  return (
+    Object.keys(DEFAULT_ASTRO_GRAB_THEME) as Array<keyof AstroGrabTheme>
+  ).every((key) => theme[key] === DEFAULT_ASTRO_GRAB_THEME[key]);
+}

--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -12,11 +12,18 @@
  * Persists preferences to localStorage under "astro-grab-toolbar-config".
  */
 
+import { DEFAULT_ASTRO_GRAB_THEME, isDefaultTheme } from "./theme.js";
+import type { AstroGrabTheme } from "./types.js";
+
 // ── Types ─────────────────────────────────────────────────────────────
 
 interface ToolbarConfig {
   enabled: boolean;
   key: string;
+}
+
+interface AstroGrabRuntime {
+  theme: AstroGrabTheme;
 }
 
 type ActivationKey = "Alt" | "Control" | "Meta" | "Shift";
@@ -75,6 +82,14 @@ const dispatchConfigUpdate = (key: string): void => {
   );
 };
 
+const getActiveTheme = (): AstroGrabTheme => {
+  const runtimeTheme = (window as Window & {
+    __ASTRO_GRAB__?: AstroGrabRuntime;
+  }).__ASTRO_GRAB__?.theme;
+
+  return runtimeTheme ?? DEFAULT_ASTRO_GRAB_THEME;
+};
+
 // ── Toolbar App ───────────────────────────────────────────────────────
 
 export default {
@@ -84,6 +99,7 @@ export default {
 
   init(canvas: ShadowRoot, eventTarget: EventTarget) {
     const config = getConfig();
+    let activeTheme = getActiveTheme();
 
     // ── Window container ────────────────────────────────────────────
     const toolbarWindow = document.createElement("astro-dev-toolbar-window");
@@ -193,6 +209,82 @@ export default {
     keySection.appendChild(keyRow);
     keySection.appendChild(currentKeyDisplay);
 
+    // ── Appearance section ──────────────────────────────────────────
+    const appearanceSection = document.createElement("div");
+    appearanceSection.style.cssText =
+      "display: flex; flex-direction: column; gap: 8px;";
+
+    const appearanceLabel = document.createElement("div");
+    appearanceLabel.textContent = "Appearance";
+    appearanceLabel.style.cssText = "font-size: 13px; font-weight: 500;";
+
+    const appearanceNote = document.createElement("div");
+    appearanceNote.style.cssText = "font-size: 11px; color: #9ca3af;";
+
+    const swatchGrid = document.createElement("div");
+    swatchGrid.style.cssText =
+      "display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 8px;";
+
+    const swatchItems: Array<{
+      swatch: HTMLSpanElement;
+      value: HTMLSpanElement;
+      key: keyof Pick<AstroGrabTheme, "accent" | "surface" | "overlay" | "tag">;
+    }> = [];
+
+    const createSwatch = (
+      label: string,
+      key: keyof Pick<AstroGrabTheme, "accent" | "surface" | "overlay" | "tag">
+    ): HTMLElement => {
+      const item = document.createElement("div");
+      item.style.cssText =
+        "display: flex; align-items: center; gap: 8px; padding: 8px 10px; border: 1px solid rgba(255, 255, 255, 0.08); border-radius: 6px;";
+
+      const swatch = document.createElement("span");
+      swatch.style.cssText =
+        "width: 12px; height: 12px; border-radius: 4px; border: 1px solid rgba(255, 255, 255, 0.16); flex: 0 0 auto;";
+
+      const copy = document.createElement("div");
+      copy.style.cssText = "display: flex; flex-direction: column; gap: 2px; min-width: 0;";
+
+      const name = document.createElement("span");
+      name.textContent = label;
+      name.style.cssText = "font-size: 11px; color: #d1d5db;";
+
+      const value = document.createElement("span");
+      value.style.cssText =
+        "font-size: 10px; color: #9ca3af; font-family: monospace; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;";
+
+      copy.appendChild(name);
+      copy.appendChild(value);
+      item.appendChild(swatch);
+      item.appendChild(copy);
+      swatchItems.push({ swatch, value, key });
+      return item;
+    };
+
+    swatchGrid.appendChild(createSwatch("Accent", "accent"));
+    swatchGrid.appendChild(createSwatch("Surface", "surface"));
+    swatchGrid.appendChild(createSwatch("Overlay", "overlay"));
+    swatchGrid.appendChild(createSwatch("Tag", "tag"));
+
+    const updateThemePreview = (theme: AstroGrabTheme): void => {
+      activeTheme = theme;
+      appearanceNote.textContent = isDefaultTheme(theme)
+        ? "OmniAura defaults"
+        : "Customized in config";
+
+      for (const item of swatchItems) {
+        item.swatch.style.backgroundColor = theme[item.key];
+        item.value.textContent = theme[item.key];
+      }
+    };
+
+    updateThemePreview(activeTheme);
+
+    appearanceSection.appendChild(appearanceLabel);
+    appearanceSection.appendChild(appearanceNote);
+    appearanceSection.appendChild(swatchGrid);
+
     // ── Status section ──────────────────────────────────────────────
     const statusSection = document.createElement("div");
     statusSection.style.cssText =
@@ -222,6 +314,7 @@ export default {
     // ── Assemble ────────────────────────────────────────────────────
     content.appendChild(enableSection);
     content.appendChild(keySection);
+    content.appendChild(appearanceSection);
     content.appendChild(statusSection);
 
     toolbarWindow.appendChild(header);
@@ -274,6 +367,14 @@ export default {
         stateBadge.style.backgroundColor = "rgba(255, 255, 255, 0.1)";
         stateBadge.style.color = "#d1d5db";
         stateDescription.textContent = "Waiting for activation key";
+      }
+    }) as EventListener);
+
+    window.addEventListener("astro-grab:ready", ((
+      e: CustomEvent<{ theme?: AstroGrabTheme }>
+    ) => {
+      if (e.detail?.theme) {
+        updateThemePreview(e.detail.theme);
       }
     }) as EventListener);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,25 @@ export interface GrabbedContext {
 
 // ── Configuration ────────────────────────────────────────────────────
 
+export interface AstroGrabTheme {
+  /** Primary accent used for outlines and emphasis. */
+  accent: string;
+  /** Softer accent used for badge and component labels. */
+  accentSoft: string;
+  /** Background color for tooltip, toast, and badge surfaces. */
+  surface: string;
+  /** Primary text color for overlay UI. */
+  text: string;
+  /** Highlight tint drawn over the targeted element. */
+  overlay: string;
+  /** Border color for tooltip, toast, and badge surfaces. */
+  border: string;
+  /** Crosshair guide line color. */
+  crosshair: string;
+  /** Element tag color inside the tooltip. */
+  tag: string;
+}
+
 export interface AstroGrabOptions {
   /**
    * Key to hold while hovering to activate the overlay.
@@ -74,6 +93,12 @@ export interface AstroGrabOptions {
    * @default true
    */
   showToast?: boolean;
+
+  /**
+   * Override the overlay look and feel.
+   * Omitted values fall back to the built-in OmniAura theme.
+   */
+  theme?: Partial<AstroGrabTheme>;
 }
 
 // ── Astro integration options ────────────────────────────────────────
@@ -103,6 +128,12 @@ export interface AstroGrabIntegrationOptions {
    * @default "Alt"
    */
   key?: "Alt" | "Control" | "Meta" | "Shift";
+
+  /**
+   * Override the runtime overlay theme.
+   * Omitted values fall back to the built-in OmniAura theme.
+   */
+  theme?: Partial<AstroGrabTheme>;
 }
 
 // ── Vite plugin options (internal, used by integration) ──────────────
@@ -132,6 +163,12 @@ export interface AstroGrabViteOptions {
    * @default "Alt"
    */
   key?: "Alt" | "Control" | "Meta" | "Shift";
+
+  /**
+   * Override the runtime overlay theme.
+   * Omitted values fall back to the built-in OmniAura theme.
+   */
+  theme?: Partial<AstroGrabTheme>;
 }
 
 // ── Data attribute names ─────────────────────────────────────────────

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -21,6 +21,7 @@
 import { readFile } from "fs/promises";
 import type { Plugin, ResolvedConfig, ViteDevServer } from "vite";
 import { transformAstroFile } from "./astro-transform.js";
+import { resolveTheme } from "./theme.js";
 import type { AstroGrabViteOptions } from "./types.js";
 import { createSnippetMiddleware } from "./snippet-server.js";
 
@@ -188,7 +189,10 @@ export default function astroGrabVite(
     componentLocation = true,
     autoImport = true,
     key = "Alt",
+    theme,
   } = options;
+
+  const resolvedTheme = resolveTheme(theme);
 
   let projectRoot = "";
 
@@ -207,7 +211,7 @@ export default function astroGrabVite(
 
     async load(id) {
       if (id === RESOLVED_VIRTUAL_INIT) {
-        return `import { initAstroGrab } from "@omniaura/astro-grab/client";\ninitAstroGrab({ key: ${JSON.stringify(key)} });`;
+        return `import { initAstroGrab } from "@omniaura/astro-grab/client";\ninitAstroGrab({ key: ${JSON.stringify(key)}, theme: ${JSON.stringify(resolvedTheme)} });`;
       }
 
       if (!id.endsWith(".astro") || id.includes("node_modules")) {

--- a/tests/overlay.test.ts
+++ b/tests/overlay.test.ts
@@ -61,6 +61,19 @@ describe("Overlay", () => {
     it("is safe to call unmount without mount", () => {
       expect(() => overlay.unmount()).not.toThrow();
     });
+
+    it("injects theme styles using overrides while preserving defaults", () => {
+      overlay = new Overlay({
+        accent: "#00ffaa",
+        surface: "#101010",
+      });
+      overlay.mount();
+
+      const styleEl = document.head.querySelector("style");
+      expect(styleEl?.textContent).toContain("#00ffaa");
+      expect(styleEl?.textContent).toContain("#101010");
+      expect(styleEl?.textContent).toContain("rgba(188, 82, 238, 0.08)");
+    });
   });
 
   describe("highlight", () => {

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_ASTRO_GRAB_THEME, isDefaultTheme, resolveTheme } from "../src/theme.js";
+
+describe("theme helpers", () => {
+  it("returns the built-in theme when no overrides are provided", () => {
+    expect(resolveTheme()).toEqual(DEFAULT_ASTRO_GRAB_THEME);
+  });
+
+  it("merges partial overrides onto the built-in theme", () => {
+    expect(resolveTheme({ accent: "#00ffaa", surface: "#101010" })).toEqual({
+      ...DEFAULT_ASTRO_GRAB_THEME,
+      accent: "#00ffaa",
+      surface: "#101010",
+    });
+  });
+
+  it("ignores blank theme values", () => {
+    expect(resolveTheme({ accent: "   " })).toEqual(DEFAULT_ASTRO_GRAB_THEME);
+  });
+
+  it("detects whether the active theme matches defaults", () => {
+    expect(isDefaultTheme(DEFAULT_ASTRO_GRAB_THEME)).toBe(true);
+    expect(isDefaultTheme(resolveTheme({ accent: "#00ffaa" }))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add a small `theme` surface for the overlay runtime and integration while preserving the current OmniAura defaults
- surface the active/default theme in the Astro Dev Toolbar so appearance values are visible without cloning upstream UI complexity
- document the new theme options and cover theme resolution in tests

## Verification
- bun test
- bun run typecheck
- bun run build
