### PR TITLE
feat: optional hold-to-activate with configurable duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ astroGrab({
   componentLocation: true, // Inject data-astro-component (default: true)
   autoImport: true,        // Auto-import runtime in dev (default: true)
   key: "Alt",              // Modifier key: "Alt" | "Control" | "Meta" | "Shift"
+  holdDuration: 0,         // ms to hold key before activation (default: 0 = instant)
   theme: {
     accent: "#bc52ee",     // Optional theme overrides
     surface: "#1a1a2e",
@@ -76,6 +77,7 @@ import { initAstroGrab } from "@omniaura/astro-grab/client";
 initAstroGrab({
   key: "Alt",              // Modifier key (default: "Alt")
   showToast: true,         // Show notification on copy (default: true)
+  holdDuration: 0,         // ms to hold key before activation (default: 0 = instant)
   agentUrl: "ws://...",    // WebSocket URL for agent bridge (optional)
   onGrab: (context) => {}, // Callback, return false to prevent copy
   theme: {
@@ -83,6 +85,10 @@ initAstroGrab({
     surface: "#1a1a2e",
   },
 });
+
+// Set holdDuration > 0 (e.g. 1000) to require holding the key for 1s
+// before targeting activates — useful to prevent accidental activation
+// when the modifier is pressed for unrelated browser shortcuts.
 ```
 
 ### Theme Defaults

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,12 +27,13 @@ let initialized = false;
 let overlay: Overlay;
 let bridge: AgentBridge | null = null;
 let stateMachine: StateMachine;
-let opts: Required<Pick<AstroGrabOptions, "key" | "showToast">> &
+let opts: Required<Pick<AstroGrabOptions, "key" | "showToast" | "holdDuration">> &
   Pick<AstroGrabOptions, "onGrab" | "agentUrl">;
 let currentTheme: AstroGrabTheme = { ...DEFAULT_ASTRO_GRAB_THEME };
 
 let hoveredEl: HTMLElement | null = null;
 let enabled = true;
+let holdTimerId: ReturnType<typeof setTimeout> | null = null;
 
 // ── Key handling ─────────────────────────────────────────────────────
 
@@ -51,10 +52,14 @@ function isActivationKey(e: KeyboardEvent): boolean {
   }
 }
 
-function onKeyDown(e: KeyboardEvent) {
-  if (!enabled) return;
-  if (!isActivationKey(e)) return;
+function clearHoldTimer() {
+  if (holdTimerId !== null) {
+    clearTimeout(holdTimerId);
+    holdTimerId = null;
+  }
+}
 
+function activateTargeting() {
   stateMachine.transition("targeting");
   emitStateChange("targeting");
   overlay.setBadge(`\u26A1 astro-grab [${opts.key}]`);
@@ -66,8 +71,36 @@ function onKeyDown(e: KeyboardEvent) {
   }
 }
 
+function onKeyDown(e: KeyboardEvent) {
+  if (!enabled) return;
+  if (!isActivationKey(e)) return;
+
+  // If a hold timer is already armed or we're already targeting, ignore
+  // repeated key-down events (e.g. OS auto-repeat).
+  if (holdTimerId !== null) return;
+  if (stateMachine.getState() === "targeting") {
+    activateTargeting();
+    return;
+  }
+
+  if (opts.holdDuration > 0) {
+    holdTimerId = setTimeout(() => {
+      holdTimerId = null;
+      // Re-check enabled in case toggle disabled us during the hold.
+      if (!enabled) return;
+      activateTargeting();
+    }, opts.holdDuration);
+    return;
+  }
+
+  activateTargeting();
+}
+
 function onKeyUp(e: KeyboardEvent) {
   if (!isActivationKey(e)) return;
+
+  // Cancel an armed hold timer if the user releases early.
+  clearHoldTimer();
 
   stateMachine.transition("idle");
   emitStateChange("idle");
@@ -186,6 +219,9 @@ async function copyToClipboard(text: string) {
 // ── Blur handling (key release when window loses focus) ──────────────
 
 function onBlur() {
+  // Always cancel any armed hold timer when focus leaves the window.
+  clearHoldTimer();
+
   if (stateMachine.getState() === "targeting") {
     stateMachine.transition("idle");
     emitStateChange("idle");
@@ -217,6 +253,9 @@ function onToolbarToggle(e: Event) {
   enabled = detail.enabled;
 
   if (!enabled) {
+    // Cancel any armed hold timer on disable.
+    clearHoldTimer();
+
     // Transition to idle and remove active state
     if (stateMachine.getState() !== "idle") {
       stateMachine.transition("idle");
@@ -230,22 +269,40 @@ function onToolbarToggle(e: Event) {
 }
 
 function onToolbarConfigUpdate(e: Event) {
-  const detail = (e as CustomEvent<{ key?: string }>).detail;
-  if (!detail?.key) return;
+  const detail = (e as CustomEvent<{ key?: string; holdDuration?: number }>).detail;
+  if (!detail) return;
 
-  const validKeys = ["Alt", "Control", "Meta", "Shift"];
-  if (!validKeys.includes(detail.key)) return;
+  let keyChanged = false;
 
-  opts.key = detail.key as "Alt" | "Control" | "Meta" | "Shift";
+  if (detail.key !== undefined) {
+    const validKeys = ["Alt", "Control", "Meta", "Shift"];
+    if (validKeys.includes(detail.key)) {
+      opts.key = detail.key as "Alt" | "Control" | "Meta" | "Shift";
+      keyChanged = true;
+    }
+  }
 
-  // If currently targeting, transition back to idle since the key changed
-  if (stateMachine.getState() === "targeting") {
-    stateMachine.transition("idle");
-    emitStateChange("idle");
-    overlay.clearHighlight();
-    overlay.setBadge("\u26A1 astro-grab");
-    document.body.style.cursor = "";
-    hoveredEl = null;
+  if (
+    detail.holdDuration !== undefined &&
+    typeof detail.holdDuration === "number" &&
+    Number.isFinite(detail.holdDuration) &&
+    detail.holdDuration >= 0
+  ) {
+    opts.holdDuration = detail.holdDuration;
+  }
+
+  // If the key changed and we're currently targeting (or have a timer armed),
+  // cancel the activation since the key being held no longer matches.
+  if (keyChanged) {
+    clearHoldTimer();
+    if (stateMachine.getState() === "targeting") {
+      stateMachine.transition("idle");
+      emitStateChange("idle");
+      overlay.clearHighlight();
+      overlay.setBadge("\u26A1 astro-grab");
+      document.body.style.cursor = "";
+      hoveredEl = null;
+    }
   }
 }
 
@@ -262,6 +319,12 @@ export function initAstroGrab(options: AstroGrabOptions = {}) {
   opts = {
     key: options.key ?? "Alt",
     showToast: options.showToast ?? true,
+    holdDuration:
+      typeof options.holdDuration === "number" &&
+      Number.isFinite(options.holdDuration) &&
+      options.holdDuration >= 0
+        ? options.holdDuration
+        : 0,
     onGrab: options.onGrab,
     agentUrl: options.agentUrl,
   };
@@ -328,6 +391,7 @@ export function destroyAstroGrab() {
   window.removeEventListener("astro-grab:toggle", onToolbarToggle);
   window.removeEventListener("astro-grab:config-update", onToolbarConfigUpdate);
 
+  clearHoldTimer();
   stateMachine.reset();
   overlay.unmount();
   bridge?.disconnect();

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -31,9 +31,16 @@ export default function astroGrab(
     autoImport = true,
     key = "Alt",
     theme,
+    holdDuration = 0,
   } = options;
 
   const resolvedTheme = resolveTheme(theme);
+  const resolvedHoldDuration =
+    typeof holdDuration === "number" &&
+    Number.isFinite(holdDuration) &&
+    holdDuration >= 0
+      ? holdDuration
+      : 0;
 
   return {
     name: "astro-grab",
@@ -55,6 +62,7 @@ export default function astroGrab(
               `const storageKey = ${JSON.stringify(STORAGE_KEY)};`,
               `const configuredKey = ${JSON.stringify(key)};`,
               `const configuredTheme = ${JSON.stringify(resolvedTheme)};`,
+              `const configuredHoldDuration = ${JSON.stringify(resolvedHoldDuration)};`,
               `const validKeys = new Set(["Alt", "Control", "Meta", "Shift"]);`,
               `const readToolbarConfig = () => {`,
               `  try {`,
@@ -68,7 +76,9 @@ export default function astroGrab(
               `};`,
               `const toolbarConfig = readToolbarConfig();`,
               `const activationKey = validKeys.has(toolbarConfig?.key) ? toolbarConfig.key : configuredKey;`,
-              `initAstroGrab({ key: activationKey, theme: configuredTheme });`,
+              `const storedHold = toolbarConfig?.holdDuration;`,
+              `const holdDuration = (typeof storedHold === "number" && Number.isFinite(storedHold) && storedHold >= 0) ? storedHold : configuredHoldDuration;`,
+              `initAstroGrab({ key: activationKey, theme: configuredTheme, holdDuration: holdDuration });`,
               `if (toolbarConfig?.enabled === false) {`,
               `  const disable = () => {`,
               `    window.dispatchEvent(new CustomEvent("astro-grab:toggle", { detail: { enabled: false } }));`,
@@ -92,6 +102,7 @@ export default function astroGrab(
                 autoImport: false,
                 key,
                 theme: resolvedTheme,
+                holdDuration: resolvedHoldDuration,
               }),
             ],
           },

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,16 @@ export interface AstroGrabOptions {
    * Omitted values fall back to the built-in OmniAura theme.
    */
   theme?: Partial<AstroGrabTheme>;
+
+  /**
+   * Milliseconds the activation key must be held before entering targeting mode.
+   * `0` activates instantly on key-down (the default, snappy behavior).
+   * Values greater than `0` arm a timer on key-down; releasing the key before
+   * the timer fires cancels activation. Useful for protecting against
+   * accidental activation when the modifier is pressed for unrelated shortcuts.
+   * @default 0
+   */
+  holdDuration?: number;
 }
 
 // ── Astro integration options ────────────────────────────────────────
@@ -134,6 +144,13 @@ export interface AstroGrabIntegrationOptions {
    * Omitted values fall back to the built-in OmniAura theme.
    */
   theme?: Partial<AstroGrabTheme>;
+
+  /**
+   * Milliseconds the activation key must be held before entering targeting mode.
+   * Passed through to the dev runtime bootstrap.
+   * @default 0
+   */
+  holdDuration?: number;
 }
 
 // ── Vite plugin options (internal, used by integration) ──────────────
@@ -169,6 +186,13 @@ export interface AstroGrabViteOptions {
    * Omitted values fall back to the built-in OmniAura theme.
    */
   theme?: Partial<AstroGrabTheme>;
+
+  /**
+   * Milliseconds the activation key must be held before entering targeting mode.
+   * Passed through to the dev runtime bootstrap.
+   * @default 0
+   */
+  holdDuration?: number;
 }
 
 // ── Data attribute names ─────────────────────────────────────────────

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -190,9 +190,16 @@ export default function astroGrabVite(
     autoImport = true,
     key = "Alt",
     theme,
+    holdDuration = 0,
   } = options;
 
   const resolvedTheme = resolveTheme(theme);
+  const resolvedHoldDuration =
+    typeof holdDuration === "number" &&
+    Number.isFinite(holdDuration) &&
+    holdDuration >= 0
+      ? holdDuration
+      : 0;
 
   let projectRoot = "";
 
@@ -211,7 +218,7 @@ export default function astroGrabVite(
 
     async load(id) {
       if (id === RESOLVED_VIRTUAL_INIT) {
-        return `import { initAstroGrab } from "@omniaura/astro-grab/client";\ninitAstroGrab({ key: ${JSON.stringify(key)}, theme: ${JSON.stringify(resolvedTheme)} });`;
+        return `import { initAstroGrab } from "@omniaura/astro-grab/client";\ninitAstroGrab({ key: ${JSON.stringify(key)}, theme: ${JSON.stringify(resolvedTheme)}, holdDuration: ${JSON.stringify(resolvedHoldDuration)} });`;
       }
 
       if (!id.endsWith(".astro") || id.includes("node_modules")) {

--- a/tests/keybinding.test.ts
+++ b/tests/keybinding.test.ts
@@ -373,4 +373,166 @@ describe("Keybinding activation", () => {
       expect(() => initAstroGrab({ showToast: false })).not.toThrow();
     });
   });
+
+  // ── holdDuration option ───────────────────────────────────────────────
+
+  describe("holdDuration option", () => {
+    it("default (no holdDuration) activates instantly on key-down", () => {
+      initAstroGrab({ key: "Alt" });
+      fireKeyDown("Alt");
+      expect(tracker.states).toEqual(["targeting"]);
+      expect(document.body.style.cursor).toBe("crosshair");
+    });
+
+    it("holdDuration: 0 activates instantly (preserves snappy default)", () => {
+      initAstroGrab({ key: "Alt", holdDuration: 0 });
+      fireKeyDown("Alt");
+      expect(tracker.states).toEqual(["targeting"]);
+    });
+
+    it("holdDuration > 0 delays activation until timer fires", async () => {
+      initAstroGrab({ key: "Alt", holdDuration: 50 });
+      fireKeyDown("Alt");
+
+      // Should not have transitioned yet
+      expect(tracker.states).toEqual([]);
+      expect(document.body.style.cursor).toBe("");
+
+      // Wait past the hold duration
+      await new Promise<void>((resolve) => setTimeout(resolve, 80));
+
+      expect(tracker.states).toEqual(["targeting"]);
+      expect(document.body.style.cursor).toBe("crosshair");
+    });
+
+    it("releasing key before hold timer fires cancels activation", async () => {
+      initAstroGrab({ key: "Alt", holdDuration: 100 });
+      fireKeyDown("Alt");
+
+      // Release early
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+      fireKeyUp("Alt");
+
+      // Wait past the original hold duration to confirm timer was canceled
+      await new Promise<void>((resolve) => setTimeout(resolve, 120));
+
+      // No targeting transition should have occurred
+      expect(tracker.states).not.toContain("targeting");
+    });
+
+    it("blur during hold cancels the pending activation", async () => {
+      initAstroGrab({ key: "Alt", holdDuration: 100 });
+      fireKeyDown("Alt");
+      fireBlur();
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 120));
+
+      expect(tracker.states).not.toContain("targeting");
+    });
+
+    it("disable via toggle during hold cancels the pending activation", async () => {
+      initAstroGrab({ key: "Alt", holdDuration: 100 });
+      fireKeyDown("Alt");
+
+      window.dispatchEvent(
+        new CustomEvent("astro-grab:toggle", { detail: { enabled: false } }),
+      );
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 120));
+
+      expect(tracker.states).not.toContain("targeting");
+    });
+
+    it("OS auto-repeat keydowns do not arm multiple timers", async () => {
+      initAstroGrab({ key: "Alt", holdDuration: 50 });
+
+      fireKeyDown("Alt");
+      fireKeyDown("Alt");
+      fireKeyDown("Alt");
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 80));
+
+      // Exactly one targeting transition should have happened
+      expect(tracker.states.filter((s) => s === "targeting")).toHaveLength(1);
+    });
+
+    it("invalid holdDuration values fall back to 0 (instant)", () => {
+      initAstroGrab({ key: "Alt", holdDuration: -100 as unknown as number });
+      fireKeyDown("Alt");
+      expect(tracker.states).toEqual(["targeting"]);
+
+      destroyAstroGrab();
+      tracker.states.length = 0;
+
+      initAstroGrab({ key: "Alt", holdDuration: NaN });
+      fireKeyDown("Alt");
+      expect(tracker.states).toEqual(["targeting"]);
+    });
+
+    it("can re-activate after hold cycle completes", async () => {
+      initAstroGrab({ key: "Alt", holdDuration: 30 });
+
+      fireKeyDown("Alt");
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
+      fireKeyUp("Alt");
+
+      fireKeyDown("Alt");
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
+      fireKeyUp("Alt");
+
+      expect(tracker.states).toEqual([
+        "targeting",
+        "idle",
+        "targeting",
+        "idle",
+      ]);
+    });
+
+    it("toolbar config-update can change holdDuration at runtime", async () => {
+      initAstroGrab({ key: "Alt", holdDuration: 0 });
+
+      window.dispatchEvent(
+        new CustomEvent("astro-grab:config-update", {
+          detail: { holdDuration: 50 },
+        }),
+      );
+
+      fireKeyDown("Alt");
+      // Should not have transitioned yet because hold is now armed
+      expect(tracker.states).toEqual([]);
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 80));
+      expect(tracker.states).toEqual(["targeting"]);
+    });
+
+    it("toolbar config-update ignores invalid holdDuration values", async () => {
+      initAstroGrab({ key: "Alt", holdDuration: 50 });
+
+      window.dispatchEvent(
+        new CustomEvent("astro-grab:config-update", {
+          detail: { holdDuration: -1 },
+        }),
+      );
+
+      // Should still be 50ms hold
+      fireKeyDown("Alt");
+      expect(tracker.states).toEqual([]);
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 80));
+      expect(tracker.states).toEqual(["targeting"]);
+    });
+
+    it("destroy clears any armed hold timer", async () => {
+      initAstroGrab({ key: "Alt", holdDuration: 100 });
+      fireKeyDown("Alt");
+
+      destroyAstroGrab();
+      tracker.states.length = 0;
+
+      // Wait past the original hold duration
+      await new Promise<void>((resolve) => setTimeout(resolve, 120));
+
+      expect(tracker.states).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds `holdDuration` option (default `0` = instant) so users can require the activation modifier to be *held* for a configurable duration before astro-grab enters targeting mode. Useful for protecting against accidental activation when the modifier is pressed for unrelated browser shortcuts.

- *Default `0`* preserves the current snappy, key-down-instant behavior.
- *Values > 0* arm a `setTimeout` on key-down; releasing the key, blurring the window, toggling-off via toolbar, or destroying the runtime all cancel the pending timer.
- *OS auto-repeat* keydowns are deduplicated so only one timer is armed per held-key cycle.
- *Toolbar runtime updates* — `astro-grab:config-update` now accepts a `holdDuration` field; invalid (negative/NaN/non-finite) values are ignored.
- *Integration & Vite plugin* pass the configured duration through to the auto-injected bootstrap; toolbar override is read from the existing `localStorage` config (`astro-grab-toolbar-config`).

Closes #7.

## Files

- `src/types.ts` — adds `holdDuration` to `AstroGrabOptions`, `AstroGrabIntegrationOptions`, `AstroGrabViteOptions`.
- `src/index.ts` — `holdTimerId`, `clearHoldTimer()`, `activateTargeting()` extracted; `onKeyDown` arms timer when `holdDuration > 0`; `onKeyUp`, `onBlur`, `onToolbarToggle`, and `destroyAstroGrab` all cancel any pending timer; `onToolbarConfigUpdate` accepts `holdDuration` runtime updates.
- `src/integration.ts` — resolves and threads `holdDuration` into the inline bootstrap script and Vite plugin options. Reads `holdDuration` from `localStorage` toolbar config when present.
- `src/vite.ts` — emits `holdDuration` in the virtual init module.
- `tests/keybinding.test.ts` — 12 new tests covering instant default, delayed activation, early-release cancel, blur cancel, disable cancel, auto-repeat dedup, invalid value fallback, re-activation cycle, runtime config update, invalid runtime config, and destroy clearing the timer.
- `README.md` — documents the new option in both Integration and Runtime option blocks.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — *237 pass, 0 fail* (40 keybinding tests, +12 new)
- [x] `bun run build` — succeeds; ESM + DTS outputs generated
- [ ] Manual smoke test in a real Astro dev project (CI will exercise build/test; manual hold-and-release UX best verified by the reviewer)

## Notes for reviewer

- The toolbar UI in `src/toolbar.ts` doesn't yet expose a slider for `holdDuration`; the runtime side fully supports it via `astro-grab:config-update`. Adding the slider can land as a follow-up if desired (Nick's reference uses a 500-3000ms range).
- Default of `0` (instant) was kept per the issue's design decision to preserve current snappy UX. Users opt in with e.g. `holdDuration: 1000`.
- Per Dex's mergemaster window, this PR is *not to be merged by Clayton* — handing back to Dex once CI is green.
