### PR TITLE
feat: add clipboard templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ astroGrab({
   componentLocation: true, // Inject data-astro-component (default: true)
   autoImport: true,        // Auto-import runtime in dev (default: true)
   key: "Alt",              // Modifier key: "Alt" | "Control" | "Meta" | "Shift"
+  template: "Element: {{tagName}}\nSource: {{source}}\n\n{{html}}",
   theme: {
     accent: "#bc52ee",     // Optional theme overrides
     surface: "#1a1a2e",
@@ -77,6 +78,7 @@ initAstroGrab({
   key: "Alt",              // Modifier key (default: "Alt")
   showToast: true,         // Show notification on copy (default: true)
   agentUrl: "ws://...",    // WebSocket URL for agent bridge (optional)
+  template: "Element: {{tagName}}\nSource: {{source}}\n\n{{html}}",
   onGrab: (context) => {}, // Callback, return false to prevent copy
   theme: {
     accent: "#bc52ee",
@@ -84,6 +86,21 @@ initAstroGrab({
   },
 });
 ```
+
+Omit `template` to keep the built-in astro-grab context format. Template
+placeholders use `{{variable}}` interpolation. Available variables:
+
+- `tagName`
+- `source`
+- `components`
+- `html`
+- `file`
+- `line`
+- `snippet`
+- `startLine`
+- `endLine`
+- `targetLine`
+- `language`
 
 ### Theme Defaults
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ let overlay: Overlay;
 let bridge: AgentBridge | null = null;
 let stateMachine: StateMachine;
 let opts: Required<Pick<AstroGrabOptions, "key" | "showToast">> &
-  Pick<AstroGrabOptions, "onGrab" | "agentUrl">;
+  Pick<AstroGrabOptions, "onGrab" | "agentUrl" | "template">;
 let currentTheme: AstroGrabTheme = { ...DEFAULT_ASTRO_GRAB_THEME };
 
 let hoveredEl: HTMLElement | null = null;
@@ -123,7 +123,7 @@ async function onMouseDown(e: MouseEvent) {
   e.stopPropagation();
 
   // Inspect the element
-  const context = inspect(target);
+  const context = inspect(target, opts.template);
 
   // Attempt to fetch a source snippet from the dev server
   if (context.elementSource) {
@@ -132,7 +132,7 @@ async function onMouseDown(e: MouseEvent) {
     if (snippet) {
       context.snippet = snippet;
       // Re-format with the snippet included
-      context.formatted = formatContext(context);
+      context.formatted = formatContext(context, opts.template);
     }
   }
 
@@ -205,7 +205,7 @@ function emitStateChange(state: string) {
 function emitReady() {
   window.dispatchEvent(
     new CustomEvent("astro-grab:ready", {
-      detail: { key: opts.key, theme: currentTheme },
+      detail: { key: opts.key, theme: currentTheme, template: opts.template },
     })
   );
 }
@@ -230,11 +230,17 @@ function onToolbarToggle(e: Event) {
 }
 
 function onToolbarConfigUpdate(e: Event) {
-  const detail = (e as CustomEvent<{ key?: string }>).detail;
-  if (!detail?.key) return;
+  const detail = (e as CustomEvent<{ key?: string; template?: string }>).detail;
+  if (!detail) return;
 
   const validKeys = ["Alt", "Control", "Meta", "Shift"];
-  if (!validKeys.includes(detail.key)) return;
+
+  if (detail.template !== undefined) {
+    opts.template = detail.template || undefined;
+    window.__ASTRO_GRAB__.template = opts.template;
+  }
+
+  if (!detail.key || !validKeys.includes(detail.key)) return;
 
   opts.key = detail.key as "Alt" | "Control" | "Meta" | "Shift";
 
@@ -264,10 +270,12 @@ export function initAstroGrab(options: AstroGrabOptions = {}) {
     showToast: options.showToast ?? true,
     onGrab: options.onGrab,
     agentUrl: options.agentUrl,
+    template: options.template,
   };
   currentTheme = resolveTheme(options.theme);
   if (typeof window !== "undefined") {
     window.__ASTRO_GRAB__.theme = currentTheme;
+    window.__ASTRO_GRAB__.template = opts.template;
   }
 
   // Create state machine and overlay
@@ -336,6 +344,7 @@ export function destroyAstroGrab() {
   currentTheme = { ...DEFAULT_ASTRO_GRAB_THEME };
   if (typeof window !== "undefined") {
     window.__ASTRO_GRAB__.theme = currentTheme;
+    window.__ASTRO_GRAB__.template = undefined;
   }
   document.body.style.cursor = "";
 }
@@ -357,6 +366,7 @@ declare global {
       destroy: typeof destroyAstroGrab;
       inspect: typeof inspect;
       theme: AstroGrabTheme;
+      template?: string;
     };
   }
 }
@@ -367,5 +377,6 @@ if (typeof window !== "undefined") {
     destroy: destroyAstroGrab,
     inspect,
     theme: currentTheme,
+    template: undefined,
   };
 }

--- a/src/inspector.ts
+++ b/src/inspector.ts
@@ -134,6 +134,46 @@ function getElementSnippet(el: HTMLElement, maxLen = 200): string {
   return html.slice(0, maxLen) + "...";
 }
 
+function formatSource(source: SourceLocation | null): string {
+  if (!source) return "";
+  return `${source.file}:${source.line}:${source.column}`;
+}
+
+function formatComponentTree(components: ComponentInfo[]): string {
+  return components
+    .map((comp) => {
+      const loc = comp.location ? ` -> ${formatSource(comp.location)}` : "";
+      return `<${comp.name} />${loc}`;
+    })
+    .join("\n");
+}
+
+function getTemplateVariables(ctx: Omit<GrabbedContext, "formatted">): Record<string, string> {
+  return {
+    tagName: ctx.tagName,
+    source: formatSource(ctx.elementSource),
+    components: formatComponentTree(ctx.components),
+    html: getElementSnippet(ctx.element, 500),
+    file: ctx.elementSource?.file ?? ctx.snippet?.file ?? "",
+    line: ctx.elementSource ? String(ctx.elementSource.line) : "",
+    snippet: ctx.snippet?.snippet ?? "",
+    startLine: ctx.snippet ? String(ctx.snippet.startLine) : "",
+    endLine: ctx.snippet ? String(ctx.snippet.endLine) : "",
+    targetLine: ctx.snippet ? String(ctx.snippet.targetLine) : "",
+    language: ctx.snippet?.language ?? "",
+  };
+}
+
+export function interpolateTemplate(
+  template: string,
+  ctx: Omit<GrabbedContext, "formatted">
+): string {
+  const variables = getTemplateVariables(ctx);
+  return template.replace(/\{\{\s*([A-Za-z][A-Za-z0-9_]*)\s*\}\}/g, (_match, key: string) => {
+    return variables[key] ?? "";
+  });
+}
+
 /**
  * Get key attributes of an element as a summary.
  */
@@ -164,7 +204,14 @@ function getElementSummary(el: HTMLElement): string {
 /**
  * Format the full grabbed context into a string for AI agent prompts.
  */
-export function formatContext(ctx: Omit<GrabbedContext, "formatted">): string {
+export function formatContext(
+  ctx: Omit<GrabbedContext, "formatted">,
+  template?: string
+): string {
+  if (template) {
+    return interpolateTemplate(template, ctx);
+  }
+
   const lines: string[] = [];
 
   lines.push("--- astro-grab context ---");
@@ -214,7 +261,7 @@ export function formatContext(ctx: Omit<GrabbedContext, "formatted">): string {
 /**
  * Inspect a DOM element and produce the full GrabbedContext.
  */
-export function inspect(el: HTMLElement): GrabbedContext {
+export function inspect(el: HTMLElement, template?: string): GrabbedContext {
   const elementSource = getElementSource(el) ?? findNearestSource(el);
   const components = getComponentChain(el);
 
@@ -228,6 +275,6 @@ export function inspect(el: HTMLElement): GrabbedContext {
 
   return {
     ...partial,
-    formatted: formatContext(partial),
+    formatted: formatContext(partial, template),
   };
 }

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -31,6 +31,7 @@ export default function astroGrab(
     autoImport = true,
     key = "Alt",
     theme,
+    template,
   } = options;
 
   const resolvedTheme = resolveTheme(theme);
@@ -55,6 +56,7 @@ export default function astroGrab(
               `const storageKey = ${JSON.stringify(STORAGE_KEY)};`,
               `const configuredKey = ${JSON.stringify(key)};`,
               `const configuredTheme = ${JSON.stringify(resolvedTheme)};`,
+              `const configuredTemplate = ${JSON.stringify(template)};`,
               `const validKeys = new Set(["Alt", "Control", "Meta", "Shift"]);`,
               `const readToolbarConfig = () => {`,
               `  try {`,
@@ -68,7 +70,8 @@ export default function astroGrab(
               `};`,
               `const toolbarConfig = readToolbarConfig();`,
               `const activationKey = validKeys.has(toolbarConfig?.key) ? toolbarConfig.key : configuredKey;`,
-              `initAstroGrab({ key: activationKey, theme: configuredTheme });`,
+              `const clipboardTemplate = typeof toolbarConfig?.template === "string" ? toolbarConfig.template : configuredTemplate;`,
+              `initAstroGrab({ key: activationKey, theme: configuredTheme, template: clipboardTemplate });`,
               `if (toolbarConfig?.enabled === false) {`,
               `  const disable = () => {`,
               `    window.dispatchEvent(new CustomEvent("astro-grab:toggle", { detail: { enabled: false } }));`,
@@ -92,6 +95,7 @@ export default function astroGrab(
                 autoImport: false,
                 key,
                 theme: resolvedTheme,
+                template,
               }),
             ],
           },

--- a/src/toolbar.ts
+++ b/src/toolbar.ts
@@ -20,10 +20,12 @@ import type { AstroGrabTheme } from "./types.js";
 interface ToolbarConfig {
   enabled: boolean;
   key: string;
+  template: string;
 }
 
 interface AstroGrabRuntime {
   theme: AstroGrabTheme;
+  template?: string;
 }
 
 type ActivationKey = "Alt" | "Control" | "Meta" | "Shift";
@@ -33,10 +35,12 @@ type ActivationKey = "Alt" | "Control" | "Meta" | "Shift";
 export const STORAGE_KEY = "astro-grab-toolbar-config";
 
 const ACTIVATION_KEYS: ActivationKey[] = ["Alt", "Control", "Meta", "Shift"];
+const DEFAULT_CLIPBOARD_TEMPLATE = "";
 
 const DEFAULT_CONFIG: ToolbarConfig = {
   enabled: true,
   key: "Alt",
+  template: DEFAULT_CLIPBOARD_TEMPLATE,
 };
 
 // ── SVG Icon ──────────────────────────────────────────────────────────
@@ -55,6 +59,7 @@ const getConfig = (): ToolbarConfig => {
           ...DEFAULT_CONFIG,
           ...parsed,
           key: ACTIVATION_KEYS.includes(parsed.key) ? parsed.key : DEFAULT_CONFIG.key,
+          template: typeof parsed.template === "string" ? parsed.template : DEFAULT_CONFIG.template,
         };
       }
     }
@@ -79,6 +84,12 @@ const dispatchToggle = (enabled: boolean): void => {
 const dispatchConfigUpdate = (key: string): void => {
   window.dispatchEvent(
     new CustomEvent("astro-grab:config-update", { detail: { key } })
+  );
+};
+
+const dispatchTemplateUpdate = (template: string): void => {
+  window.dispatchEvent(
+    new CustomEvent("astro-grab:config-update", { detail: { template } })
   );
 };
 
@@ -209,6 +220,46 @@ export default {
     keySection.appendChild(keyRow);
     keySection.appendChild(currentKeyDisplay);
 
+    // ── Clipboard Template section ──────────────────────────────────
+    const templateSection = document.createElement("div");
+    templateSection.style.cssText = "display: flex; flex-direction: column; gap: 8px;";
+
+    const templateHeader = document.createElement("div");
+    templateHeader.style.cssText =
+      "display: flex; justify-content: space-between; align-items: center; gap: 8px;";
+
+    const templateLabel = document.createElement("div");
+    templateLabel.textContent = "Clipboard Template";
+    templateLabel.style.cssText = "font-size: 13px; font-weight: 500;";
+
+    const resetTemplateButton = document.createElement(
+      "astro-dev-toolbar-button"
+    ) as HTMLElement & { buttonStyle: string; size: string };
+    resetTemplateButton.textContent = "Reset";
+    resetTemplateButton.size = "small";
+    resetTemplateButton.buttonStyle = "ghost";
+    resetTemplateButton.style.cssText = "cursor: pointer;";
+
+    templateHeader.appendChild(templateLabel);
+    templateHeader.appendChild(resetTemplateButton);
+
+    const templateInput = document.createElement("textarea");
+    templateInput.value = config.template;
+    templateInput.placeholder =
+      "{{tagName}}\n{{source}}\n{{components}}\n{{html}}\n{{snippet}}";
+    templateInput.rows = 5;
+    templateInput.style.cssText =
+      "box-sizing: border-box; width: 100%; min-height: 92px; resize: vertical; padding: 8px 10px; border: 1px solid rgba(255, 255, 255, 0.12); border-radius: 6px; background: rgba(0, 0, 0, 0.22); color: #d1d5db; font: 11px/1.45 monospace; outline: none;";
+
+    const templateHelp = document.createElement("div");
+    templateHelp.textContent =
+      "Variables: tagName, source, components, html, file, line, snippet, startLine, endLine, targetLine, language";
+    templateHelp.style.cssText = "font-size: 11px; color: #9ca3af; line-height: 1.4;";
+
+    templateSection.appendChild(templateHeader);
+    templateSection.appendChild(templateInput);
+    templateSection.appendChild(templateHelp);
+
     // ── Appearance section ──────────────────────────────────────────
     const appearanceSection = document.createElement("div");
     appearanceSection.style.cssText =
@@ -314,6 +365,7 @@ export default {
     // ── Assemble ────────────────────────────────────────────────────
     content.appendChild(enableSection);
     content.appendChild(keySection);
+    content.appendChild(templateSection);
     content.appendChild(appearanceSection);
     content.appendChild(statusSection);
 
@@ -348,6 +400,19 @@ export default {
         stateBadge.style.color = "#d1d5db";
         stateDescription.textContent = "Waiting for activation key";
       }
+    });
+
+    templateInput.addEventListener("input", () => {
+      config.template = templateInput.value;
+      saveConfig(config);
+      dispatchTemplateUpdate(config.template);
+    });
+
+    resetTemplateButton.addEventListener("click", () => {
+      config.template = DEFAULT_CLIPBOARD_TEMPLATE;
+      templateInput.value = config.template;
+      saveConfig(config);
+      dispatchTemplateUpdate(config.template);
     });
 
     // Listen for state machine transitions from the client
@@ -390,6 +455,10 @@ export default {
     // Notify the client runtime to load persisted config on init
     if (config.key !== "Alt") {
       dispatchConfigUpdate(config.key);
+    }
+
+    if (config.template) {
+      dispatchTemplateUpdate(config.template);
     }
   },
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,12 @@ export interface AstroGrabOptions {
    * Omitted values fall back to the built-in OmniAura theme.
    */
   theme?: Partial<AstroGrabTheme>;
+
+  /**
+   * Clipboard template with `{{variable}}` placeholders.
+   * Omitted value falls back to the built-in astro-grab context format.
+   */
+  template?: string;
 }
 
 // ── Astro integration options ────────────────────────────────────────
@@ -134,6 +140,12 @@ export interface AstroGrabIntegrationOptions {
    * Omitted values fall back to the built-in OmniAura theme.
    */
   theme?: Partial<AstroGrabTheme>;
+
+  /**
+   * Clipboard template passed through to the dev runtime bootstrap.
+   * Omitted value falls back to the built-in astro-grab context format.
+   */
+  template?: string;
 }
 
 // ── Vite plugin options (internal, used by integration) ──────────────
@@ -169,6 +181,12 @@ export interface AstroGrabViteOptions {
    * Omitted values fall back to the built-in OmniAura theme.
    */
   theme?: Partial<AstroGrabTheme>;
+
+  /**
+   * Clipboard template passed through to the dev runtime bootstrap.
+   * Omitted value falls back to the built-in astro-grab context format.
+   */
+  template?: string;
 }
 
 // ── Data attribute names ─────────────────────────────────────────────

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -190,6 +190,7 @@ export default function astroGrabVite(
     autoImport = true,
     key = "Alt",
     theme,
+    template,
   } = options;
 
   const resolvedTheme = resolveTheme(theme);
@@ -211,7 +212,7 @@ export default function astroGrabVite(
 
     async load(id) {
       if (id === RESOLVED_VIRTUAL_INIT) {
-        return `import { initAstroGrab } from "@omniaura/astro-grab/client";\ninitAstroGrab({ key: ${JSON.stringify(key)}, theme: ${JSON.stringify(resolvedTheme)} });`;
+        return `import { initAstroGrab } from "@omniaura/astro-grab/client";\ninitAstroGrab({ key: ${JSON.stringify(key)}, theme: ${JSON.stringify(resolvedTheme)}, template: ${JSON.stringify(template)} });`;
       }
 
       if (!id.endsWith(".astro") || id.includes("node_modules")) {

--- a/tests/inspector.test.ts
+++ b/tests/inspector.test.ts
@@ -6,6 +6,7 @@ import {
   findNearestComponent,
   getComponentChain,
   formatContext,
+  interpolateTemplate,
   inspect,
   fetchSnippet,
 } from "../src/inspector.js";
@@ -558,6 +559,72 @@ describe("DOM walking", () => {
       // The class should be truncated with ...
       expect(output).toContain('class="' + "a".repeat(77) + '..."');
     });
+
+    it("formats a custom clipboard template with context variables", () => {
+      const el = document.createElement("button");
+      el.className = "btn primary";
+      el.textContent = "Save";
+
+      const output = formatContext(
+        {
+          element: el,
+          tagName: "button",
+          elementSource: { file: "src/App.astro", line: 24, column: 8 },
+          components: [
+            { name: "Counter", location: { file: "src/Counter.astro", line: 12, column: 1 } },
+          ],
+          timestamp: Date.now(),
+        },
+        "Tag: {{tagName}}\nFile: {{file}}\nLine: {{line}}\nSource: {{source}}\n{{components}}\n{{html}}"
+      );
+
+      expect(output).toContain("Tag: button");
+      expect(output).toContain("File: src/App.astro");
+      expect(output).toContain("Line: 24");
+      expect(output).toContain("Source: src/App.astro:24:8");
+      expect(output).toContain("<Counter /> -> src/Counter.astro:12:1");
+      expect(output).toContain('<button class="btn primary">Save</button>');
+    });
+
+    it("exposes snippet variables to custom clipboard templates", () => {
+      const el = document.createElement("div");
+      const snippet: SnippetResponse = {
+        file: "src/Page.astro",
+        snippet: "<Card />",
+        startLine: 5,
+        endLine: 9,
+        targetLine: 7,
+        language: "astro",
+      };
+
+      const output = formatContext(
+        {
+          element: el,
+          tagName: "div",
+          elementSource: { file: "src/Page.astro", line: 7, column: 5 },
+          components: [],
+          timestamp: Date.now(),
+          snippet,
+        },
+        "{{language}}:{{startLine}}-{{endLine}} target={{targetLine}}\n{{snippet}}"
+      );
+
+      expect(output).toBe("astro:5-9 target=7\n<Card />");
+    });
+
+    it("replaces missing template variables with empty strings", () => {
+      const el = document.createElement("div");
+
+      const output = interpolateTemplate("{{source}} {{unknown}} {{snippet}}", {
+        element: el,
+        tagName: "div",
+        elementSource: null,
+        components: [],
+        timestamp: Date.now(),
+      });
+
+      expect(output).toBe("  ");
+    });
   });
 
   describe("inspect", () => {
@@ -616,6 +683,16 @@ describe("DOM walking", () => {
       expect(ctx.formatted).toContain("--- end astro-grab context ---");
       expect(ctx.formatted).toContain("src/Form.astro:20:3");
       expect(ctx.formatted).toContain('id="submit"');
+    });
+
+    it("uses a custom template for the formatted output", () => {
+      const el = document.createElement("button");
+      el.setAttribute(ATTR_SOURCE, "src/Button.astro:10:5");
+      root.appendChild(el);
+
+      const ctx = inspect(el, "{{tagName}} {{source}}");
+
+      expect(ctx.formatted).toBe("button src/Button.astro:10:5");
     });
   });
 });


### PR DESCRIPTION
## Summary

- add `template` support to integration, Vite, and runtime options
- interpolate clipboard placeholders for DOM, source, component, HTML, and snippet fields
- expose clipboard template editing in the Astro dev toolbar
- document available template variables

Closes #6.

## Tests

- `bun run typecheck`
- `bun test`
- `bun run build`
- `git diff --check`
